### PR TITLE
Responsive meetings table

### DIFF
--- a/src/assets/src/components/edit.tsx
+++ b/src/assets/src/components/edit.tsx
@@ -59,7 +59,7 @@ function MeetingEditor(props: MeetingEditorProps) {
             <UserDisplay user={user}/>
         </td>
         <td className="form-group">
-            <select className="form-control"
+            <select className="form-control assign"
                 value={props.meeting.assignee?.id ?? ""} 
                 onChange={onChangeAssignee}>
                 {assigneeOptions}
@@ -119,7 +119,7 @@ function QueueEditor(props: QueueEditorProps) {
         .sort((a, b) => a.id - b.id)
         .map((m, i) =>
             <tr>
-                <td>{i+1}</td>
+                <th scope="row" className="d-none d-sm-table-cell">{i+1}</th>
                 <MeetingEditor key={m.id} user={props.user} potentialAssignees={props.queue.hosts} meeting={m} disabled={props.disabled}
                     onRemove={props.onRemoveMeeting} onShowMeetingInfo={props.onShowMeetingInfo} onChangeAssignee={(a: User | undefined) => props.onChangeAssignee(a, m) }/>
             </tr>
@@ -129,10 +129,10 @@ function QueueEditor(props: QueueEditorProps) {
             <Table bordered>
                 <thead>
                     <tr>
-                        <th>Queue #</th>
-                        <th>Attendee</th>
-                        <th>Host</th>
-                        <th>Actions</th>
+                        <th scope="col" className="d-none d-sm-table-cell">Queue #</th>
+                        <th scope="col">Attendee</th>
+                        <th scope="col">Host</th>
+                        <th scope="col">Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -218,7 +218,9 @@ function QueueEditor(props: QueueEditorProps) {
             <h3>Meetings Up Next</h3>
             <div className="row">
                 <div className="col-md-12">
-                    {meetingsTable}
+                    <div className="table-responsive">
+                        {meetingsTable}
+                    </div>
                 </div>
             </div>
             <div className="row">

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -537,6 +537,10 @@ h3.alert-heading {
 	border-top: 0;
 }
 
+.assign {
+	min-width: 160px;
+}
+
 .card-grid {
 	display: grid;
 	grid-template-columns: repeat(3, auto);


### PR DESCRIPTION
Addresses bad meetings editor UX on mobile.

At all screen widths, Assignee select's width is retained.

![image](https://user-images.githubusercontent.com/11338926/83330079-ec186700-a25a-11ea-906b-103e94b304b7.png)

At small screen size, the "Queue #" column is hidden.

![image](https://user-images.githubusercontent.com/11338926/83330035-b8d5d800-a25a-11ea-9643-3a18cf32dbf0.png)

At way-too-small screen sizes, the table becomes horizontally scollable.

![image](https://user-images.githubusercontent.com/11338926/83330065-db67f100-a25a-11ea-8210-11a3aca4ca75.png)
