### PR TITLE
Add Alerts to and generally improve preferences form (#102)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -4,8 +4,9 @@ import { faSyncAlt, faClipboard, faClipboardCheck, faPencilAlt, faTrashAlt, faHo
 import { User, QueueAttendee } from "../models";
 import { useState, createRef, useEffect } from "react";
 import { Link } from "react-router-dom";
-import Modal from "react-bootstrap/Modal";
+import Alert from "react-bootstrap/Alert";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
+import Modal from "react-bootstrap/Modal";
 
 type BootstrapButtonTypes = "info" | "warning" | "success" | "primary" | "alternate" | "danger";
 
@@ -94,11 +95,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = (props) => {
         (a: FormError, index: any) => (<p key={index}><b>{a.source}:</b> {a.error.message} </p>)
     );
     if (messages.length === 0) return null;
-    return (
-        <div className="alert alert-danger" role="alert">
-            {messages}
-        </div>
-    );
+    return (<Alert variant='danger'>{messages}</Alert>);
 }
 
 

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -92,7 +92,7 @@ interface ErrorDisplayProps {
 
 export const ErrorDisplay: React.FC<ErrorDisplayProps> = (props) => {
     const messages = props.formErrors.map(
-        (a: FormError, index: any) => (<p key={index}><b>{a.source}:</b> {a.error.message} </p>)
+        (a: FormError, index: number) => (<p key={index}><b>{a.source}:</b> {a.error.message} </p>)
     );
     if (messages.length === 0) return null;
     return (<Alert variant='danger'>{messages}</Alert>);

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -90,7 +90,9 @@ interface ErrorDisplayProps {
 
 
 export const ErrorDisplay: React.FC<ErrorDisplayProps> = (props) => {
-    const messages = props.formErrors.map(a => <p><b>{a.source}:</b> {a.error.message} </p>);
+    const messages = props.formErrors.map(
+        (a: FormError, index: any) => (<p key={index}><b>{a.source}:</b> {a.error.message} </p>)
+    );
     if (messages.length === 0) return null;
     return (
         <div className="alert alert-danger" role="alert">

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -92,7 +92,7 @@ interface ErrorDisplayProps {
 
 export const ErrorDisplay: React.FC<ErrorDisplayProps> = (props) => {
     const messages = props.formErrors.map(
-        (a: FormError, index: number) => (<p key={index}><b>{a.source}:</b> {a.error.message} </p>)
+        (a: FormError, index: number) => <p key={index}><b>{a.source}:</b> {a.error.message}</p>
     );
     if (messages.length === 0) return null;
     return (<Alert variant='danger'>{messages}</Alert>);

--- a/src/assets/src/components/preferences.tsx
+++ b/src/assets/src/components/preferences.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useState, useEffect } from "react";
+import { Button, Form } from "react-bootstrap";
 import PhoneInput from "react-phone-input-2";
 import 'react-phone-input-2/lib/style.css'
 
@@ -19,16 +20,18 @@ interface PreferencesEditorProps {
 function PreferencesEditor(props: PreferencesEditorProps) {
     const [phoneField, setPhoneField] = useState(props.user.phone_number);
     const [countryDialCode, setCountryDialCode] = useState("");
-    const phoneInput = <PhoneInput
-        country={'us'}
-        value={props.user.phone_number}
-        onChange={ (value, data) => {
-            setPhoneField(value);
-            if ('dialCode' in data) setCountryDialCode(data.dialCode);
-        }}
-        disabled={props.disabled}
-        inputProps={{id: 'phone'}}
-    />
+    const phoneInput = (
+        <PhoneInput
+            country={'us'}
+            value={props.user.phone_number}
+            onChange={(value: any, data: any) => {
+                setPhoneField(value);
+                if ('dialCode' in data) setCountryDialCode(data.dialCode);
+            }}
+            disabled={props.disabled}
+            inputProps={{id: 'phone'}}
+        />
+    )
     const validateAndSubmit = () => {
         // Determine if there was a change that warrants a submit
         const num = props.user.phone_number;
@@ -51,14 +54,16 @@ function PreferencesEditor(props: PreferencesEditorProps) {
     return (
         <div>
             <h1>View/Update Preferences</h1>
-            <form onSubmit={validateAndSubmit}>
+            <Form onSubmit={validateAndSubmit}>
                 <p>
                     Please provide alternate means by which the host may contact you in the event of technical difficulties.
                 </p>
-                <label htmlFor="phone">Phone Number: </label>
-                {phoneInput}
-                <input type="submit" className="btn btn-primary" value="Save" disabled={props.disabled} />
-            </form>
+                <Form.Group controlId='phone'>
+                    <Form.Label>Phone Number</Form.Label>
+                    {phoneInput}
+                </Form.Group>
+                <Button variant="primary" type="submit" disabled={props.disabled}>Save</Button>
+            </Form>
         </div>
     );
 }

--- a/src/assets/src/components/preferences.tsx
+++ b/src/assets/src/components/preferences.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useState, useEffect } from "react";
-import { Button, Form } from "react-bootstrap";
+import { Alert, Button, Form } from "react-bootstrap";
 import PhoneInput from "react-phone-input-2";
 import 'react-phone-input-2/lib/style.css'
 
@@ -15,11 +15,15 @@ interface PreferencesEditorProps {
     user: User;
     disabled: boolean;
     onUpdateInfo: (phoneNumber: string) => void;
+    errorOccurred: boolean;
 }
 
 function PreferencesEditor(props: PreferencesEditorProps) {
     const [phoneField, setPhoneField] = useState(props.user.phone_number);
     const [countryDialCode, setCountryDialCode] = useState("");
+    const [phoneIsValid, setPhoneIsValid] = useState(undefined as undefined | null | boolean)
+    const [phoneValidationError, setPhoneValidationError] = useState(undefined as undefined | string)
+
     const phoneInput = (
         <PhoneInput
             country={'us'}
@@ -32,32 +36,58 @@ function PreferencesEditor(props: PreferencesEditorProps) {
             inputProps={{id: 'phone'}}
         />
     )
-    const validateAndSubmit = () => {
+    const validateAndSubmit = (e: React.SyntheticEvent) => {
+        e.preventDefault() // Prevent page reload
         // Determine if there was a change that warrants a submit
         const num = props.user.phone_number;
+        let validCheck = null as boolean | null
+        let validationError = undefined as undefined | string
         if ((num.length === 0 && phoneField.length > countryDialCode.length) || (num.length > 0 && phoneField !== num)) {
             // If USA number, ensure it's 11 digits to submit 
             if (countryDialCode === '1') {
                 if (phoneField.length == 11) {
+                    validCheck = true
                     props.onUpdateInfo(phoneField)
+                } else {
+                    validCheck = false
+                    validationError = 'The phone number entered was invalid; USA phone numbers must have 11 digits.'
                 }
-            }
-            else {
+            } else {
+                validCheck = true
                 props.onUpdateInfo(phoneField)
             }
         }
         // update phone number to be empty if they delete everything in the phone field
         if (phoneField.length === 0) {
+            validCheck = true
             props.onUpdateInfo(phoneField)
         }
+
+        setPhoneIsValid(validCheck)
+        if (validCheck === false) {
+            setPhoneValidationError(validationError)
+        }
     }
+
+    let alertBlock
+    if (phoneIsValid === false) {
+        alertBlock = (<Alert variant='danger'>{phoneValidationError ? phoneValidationError : 'One or more of your entries is invalid.' }</Alert>)
+    } else if (phoneIsValid === null) {
+        alertBlock = (<Alert variant='primary'>Your preferences were not changed.</Alert>)
+    } else if (phoneIsValid === true && props.errorOccurred) {
+        alertBlock = (<Alert variant='danger'>An error occurred while trying to update your preferences; please try again later.</Alert>)
+    } else if (phoneIsValid === true) {
+        // props.errorOccurred === false is implied
+        alertBlock = (<Alert variant='success'>Your preferences were successfully updated.</Alert>)
+    }
+    // if alertBlock is still undefined, don't display an Alert
+
     return (
         <div>
             <h1>View/Update Preferences</h1>
+            {alertBlock}
             <Form onSubmit={validateAndSubmit}>
-                <p>
-                    Please provide alternate means by which the host may contact you in the event of technical difficulties.
-                </p>
+                <p>Please provide alternate means by which the host may contact you in the event of technical difficulties.</p>
                 <Form.Group controlId='phone'>
                     <Form.Label>Phone Number</Form.Label>
                     {phoneInput}
@@ -76,35 +106,43 @@ export function PreferencesPage(props: PageProps) {
     if (!props.user) throw new Error("user is undefined!");
     const userId = props.user.id
 
-    //Setup basic state
+    // Setup basic state
     const [user, setUser] = useState(undefined as User | undefined);
     const [doRefresh, refreshLoading, refreshError] = usePromise(() => api.getMyUser(userId) as Promise<User>, setUser);
     useEffect(() => {
         doRefresh();
     }, []);
 
-    //Setup interactions
-    const [doUpdateInfo, updateInfoLoading, updateInfoError] = usePromise((phoneNumber: string) => api.updateMyUser(userId, phoneNumber) as Promise<User>, setUser);
+    // Setup interactions
+    const [doUpdateInfo, updateInfoLoading, updateInfoError] = usePromise(
+        (phoneNumber: string) => api.updateMyUser(userId, phoneNumber) as Promise<User>, setUser
+    );
 
-    //Render
+    // Render
     const isChanging = updateInfoLoading;
     const isLoading = isChanging;
     const errorSources = [
         {source: 'Update Preferences', error: updateInfoError}
     ].filter(e => e.error) as FormError[];
     const loginDialogVisible = errorSources.some(checkForbiddenError);
-    const loadingDisplay = <LoadingDisplay loading={isLoading}/>
-    const errorDisplay = <ErrorDisplay formErrors={errorSources}/>
+    const loadingDisplay = (<LoadingDisplay loading={isLoading}/>)
+    const errorDisplay = (<ErrorDisplay formErrors={errorSources}/>)
     const preferencesEditor = user
-        && <PreferencesEditor user={user} disabled={isChanging} onUpdateInfo={doUpdateInfo}/>
+        && (
+            <PreferencesEditor
+                user={user}
+                disabled={isChanging}
+                onUpdateInfo={doUpdateInfo}
+                errorOccurred={(errorSources.length > 0) ? true : false}
+            />
+        )
     return (
         <>
-        <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl} />
-        <Breadcrumbs
-            currentPageTitle="User Preferences" />
-        {loadingDisplay}
-        {errorDisplay}
-        {preferencesEditor}
+            <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl} />
+            <Breadcrumbs currentPageTitle='User Preferences' />
+            {errorDisplay}
+            {loadingDisplay}
+            {preferencesEditor}
         </>
     );
 }

--- a/src/assets/src/components/preferences.tsx
+++ b/src/assets/src/components/preferences.tsx
@@ -75,14 +75,14 @@ function PreferencesEditor(props: PreferencesEditorProps) {
 
     let alertBlock
     if (phoneIsValid === false) {
-        alertBlock = (<Alert variant='danger'>{phoneValidationError ? phoneValidationError : 'One or more of your entries is invalid.' }</Alert>)
+        alertBlock = <Alert variant='danger'>{phoneValidationError ? phoneValidationError : 'One or more of your entries is invalid.'}</Alert>
     } else if (phoneIsValid === null) {
-        alertBlock = (<Alert variant='primary'>Your preferences were not changed.</Alert>)
+        alertBlock = <Alert variant='primary'>Your preferences were not changed.</Alert>
     } else if (phoneIsValid === true && props.errorOccurred) {
-        alertBlock = (<Alert variant='danger'>An error occurred while trying to update your preferences; please try again later.</Alert>)
+        alertBlock = <Alert variant='danger'>An error occurred while trying to update your preferences; please try again later.</Alert>
     } else if (phoneIsValid === true) {
         // props.errorOccurred === false is implied
-        alertBlock = (<Alert variant='success'>Your preferences were successfully updated.</Alert>)
+        alertBlock = <Alert variant='success'>Your preferences were successfully updated.</Alert>
     }
     // if alertBlock is still undefined, don't display an Alert
 
@@ -129,8 +129,8 @@ export function PreferencesPage(props: PageProps) {
         {source: 'Update Preferences', error: updateInfoError}
     ].filter(e => e.error) as FormError[];
     const loginDialogVisible = errorSources.some(checkForbiddenError);
-    const loadingDisplay = (<LoadingDisplay loading={isLoading}/>)
-    const errorDisplay = (<ErrorDisplay formErrors={errorSources}/>)
+    const loadingDisplay = <LoadingDisplay loading={isLoading}/>
+    const errorDisplay = <ErrorDisplay formErrors={errorSources}/>
     const preferencesEditor = user
         && (
             <PreferencesEditor

--- a/src/assets/src/components/preferences.tsx
+++ b/src/assets/src/components/preferences.tsx
@@ -42,7 +42,10 @@ function PreferencesEditor(props: PreferencesEditorProps) {
         const num = props.user.phone_number;
         let validCheck = null as boolean | null
         let validationError = undefined as undefined | string
-        if ((num.length === 0 && phoneField.length > countryDialCode.length) || (num.length > 0 && phoneField !== num)) {
+        if (
+            (num.length === 0 && phoneField.length > countryDialCode.length) ||
+            (num.length > 0 && phoneField !== num && phoneField.length > 1)
+        ) {
             // If USA number, ensure it's 11 digits to submit 
             if (countryDialCode === '1') {
                 if (phoneField.length == 11) {
@@ -56,11 +59,12 @@ function PreferencesEditor(props: PreferencesEditorProps) {
                 validCheck = true
                 props.onUpdateInfo(phoneField)
             }
-        }
-        // update phone number to be empty if they delete everything in the phone field
-        if (phoneField.length === 0) {
+        } else if (phoneField.length <= 1 && num !== '') {
+            // Update phone number to be empty if they try to delete everything in the phone field
+            // Seems to be a known issue where the last character can't be removed as part of onChange:
+            // https://github.com/bl00mber/react-phone-input-2/issues/231
             validCheck = true
-            props.onUpdateInfo(phoneField)
+            props.onUpdateInfo('')
         }
 
         setPhoneIsValid(validCheck)


### PR DESCRIPTION
This PR makes modifications to `common.tsx` and `preferences.tsx` to add alert banners for various cases (validation error, backend error, success, and no change) to the preferences form managing phone number input. It also introduces the use of more `react-bootstrap` components (`Alert`, `Button`, and `Form`) to improve styling consistency and marginally simplify code; prevents page reloading on form submissions to help with banner display; and modifies the validation logic in an attempt to handle [an apparent bug in the phone input dependency](https://github.com/bl00mber/react-phone-input-2/issues/231). Feedback on logic, design choices, and code style are welcome. I'm still getting comfortable with the codebase and TypeScript. I don't think it's perfect, but hopefully it's a step in the right direction. The PR aims to at least resolve issue #102 (and I may need to document others).