### PR TITLE
Update Manage description field form to indicate entry is over the limit (#111)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -293,6 +293,7 @@ export const SingleInputFormShowRemaining: React.FC<SingleInputFormShowRemaining
                     id={props.id}
                     as='textarea'
                     rows={5}
+                    bsPrefix='form-control form-control-remaining'
                     value={props.value}
                     placeholder={props.placeholder}
                     onChange={(e) => handleChange(e.currentTarget.value)}

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -1,12 +1,10 @@
-import * as React from "react";
+import * as React from "react"
+import { createRef, useEffect, useState } from "react"
+import { Link } from "react-router-dom"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSyncAlt, faClipboard, faClipboardCheck, faPencilAlt, faTrashAlt, faHome } from '@fortawesome/free-solid-svg-icons'
-import { User, QueueAttendee } from "../models";
-import { useState, createRef, useEffect } from "react";
-import { Link } from "react-router-dom";
-import Alert from "react-bootstrap/Alert";
-import Breadcrumb from "react-bootstrap/Breadcrumb";
-import Modal from "react-bootstrap/Modal";
+import { Alert, Breadcrumb, Button, Form, Modal } from "react-bootstrap"
+import { QueueAttendee, User } from "../models"
 
 type BootstrapButtonTypes = "info" | "warning" | "success" | "primary" | "alternate" | "danger";
 
@@ -261,8 +259,7 @@ export const EditToggleField: React.FC<EditToggleFieldProps> = (props) => {
             <div className="input-group">
                 <span>{props.text}</span>
                 <button onClick={enableEditMode} type="button" className="btn btn-sm">
-                    <FontAwesomeIcon icon={faPencilAlt} />
-                    Edit
+                    <FontAwesomeIcon icon={faPencilAlt} /> Edit
                 </button>
             </div>
         );
@@ -274,38 +271,47 @@ interface SingleInputFormShowRemainingProps extends StatelessSingleInputFormProp
 }
 
 export const SingleInputFormShowRemaining: React.FC<SingleInputFormShowRemainingProps> = (props) => {
-    const inputRef = createRef<HTMLTextAreaElement>();
-    useEffect(() => {
-        if (!props.autofocus) return;
-        inputRef.current!.focus();
-    }, []);
-    const submit = (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-        props.onSubmit(props.value);
-        props.onChangeValue("");
+    const [remaining, setRemaining] = useState(props.maxLength - props.value.length as number)
+    const [isInvalid, setIsInvalid] = useState(false as boolean)
+    const buttonClass = `btn btn-${props.buttonType} remaining-controls` as string
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        if (!isInvalid) {
+            props.onSubmit(props.value)
+            props.onChangeValue('')
+        }
     }
-    const buttonClass = "btn btn-" + props.buttonType + " remaining-controls";
-    const [remaining, setRemaining] = useState(props.maxLength - props.value.length);
-    const handleChange = (newValue:string) => {
+    const handleChange = (newValue: string) => {
         props.onChangeValue(newValue);
+        if (newValue.length <= props.maxLength) { setIsInvalid(false) } else { setIsInvalid(true) }
         setRemaining(props.maxLength - newValue.length)
     }
+
+    const charsRemaining = (remaining > 0) ? remaining : 0 as number
+    const charsOver = (remaining < 0) ? ` (${remaining * -1} over limit)` : '' as string
+    const feedbackText = `Remaining characters: ${charsRemaining}/${props.maxLength}` + charsOver as string
+
     return (
-        <form onSubmit={submit}>
-            <textarea onChange={(e) => handleChange(e.target.value)} value={props.value}
-                ref={inputRef} className="form-control" placeholder={props.placeholder}
-                disabled={props.disabled} id={props.id} rows={5}/>
-            <div>
-                <p className="remaining-controls-group">
-                    <span>{remaining}/{props.maxLength}</span>
-                    <button className={buttonClass} type="submit" disabled={props.disabled}>
-                        {props.children}
-                    </button>
-                </p>
-                
+        <Form onSubmit={handleSubmit}>
+            <Form.Group>
+                <Form.Control
+                    id={props.id}
+                    as='textarea'
+                    rows={5}
+                    value={props.value}
+                    placeholder={props.placeholder}
+                    onChange={(e) => handleChange(e.currentTarget.value)}
+                    disabled={props.disabled}
+                    isInvalid={!!isInvalid}
+                />
+            </Form.Group>
+            <div className="remaining-controls-group">
+                <span className={isInvalid ? 'text-danger' : undefined}>{feedbackText}</span>
+                <Button bsPrefix={buttonClass} type='submit' disabled={props.disabled}>{props.children}</Button>
             </div>
-        </form>
-    );
+        </Form>
+    )
 }
 
 
@@ -331,9 +337,12 @@ export const ShowRemainingField: React.FC<ShowRemainingFieldProps> = (props) => 
                 id={props.id}
                 autofocus={true}
                 onSubmit={submit}
-                value={editorValue} onChangeValue={setEditorValue}
-                placeholder={props.placeholder} disabled={props.disabled}
-                buttonType="success" maxLength={props.maxLength}>
+                value={editorValue}
+                onChangeValue={setEditorValue}
+                placeholder={props.placeholder}
+                disabled={props.disabled}
+                buttonType="success"
+                maxLength={props.maxLength}>
                 {props.children}
             </SingleInputFormShowRemaining>
         )
@@ -341,8 +350,7 @@ export const ShowRemainingField: React.FC<ShowRemainingFieldProps> = (props) => 
             <div className="input-group">
                 <span>{props.text}</span>
                 <button onClick={enableEditMode} type="button" className="btn btn-sm">
-                    <FontAwesomeIcon icon={faPencilAlt} />
-                    Edit
+                    <FontAwesomeIcon icon={faPencilAlt} /> Edit
                 </button>
             </div>
         );

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -271,24 +271,20 @@ interface SingleInputFormShowRemainingProps extends StatelessSingleInputFormProp
 }
 
 export const SingleInputFormShowRemaining: React.FC<SingleInputFormShowRemainingProps> = (props) => {
-    const [remaining, setRemaining] = useState(props.maxLength - props.value.length as number)
-    const [isInvalid, setIsInvalid] = useState(false as boolean)
-    const buttonClass = `btn btn-${props.buttonType} remaining-controls` as string
+    const buttonClass = `btn btn-${props.buttonType} remaining-controls`
+    const remaining = props.maxLength - props.value.length
+    const isInvalid = props.value.length > props.maxLength
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
         props.onSubmit(props.value)
         props.onChangeValue('')
     }
-    const handleChange = (newValue: string) => {
-        props.onChangeValue(newValue);
-        if (newValue.length <= props.maxLength) { setIsInvalid(false) } else { setIsInvalid(true) }
-        setRemaining(props.maxLength - newValue.length)
-    }
+    const handleChange = (newValue: string) => props.onChangeValue(newValue)
 
-    const charsRemaining = (remaining > 0) ? remaining : 0 as number
-    const charsOver = (remaining < 0) ? ` (${remaining * -1} over limit)` : '' as string
-    const feedbackText = `Remaining characters: ${charsRemaining}/${props.maxLength}` + charsOver as string
+    const charsRemaining = (remaining > 0) ? remaining : 0
+    const charsOver = (remaining < 0) ? ` (${remaining * -1} over limit)` : ''
+    const feedbackText = `Remaining characters: ${charsRemaining}/${props.maxLength}${charsOver}`
 
     return (
         <Form onSubmit={handleSubmit}>
@@ -301,7 +297,7 @@ export const SingleInputFormShowRemaining: React.FC<SingleInputFormShowRemaining
                     placeholder={props.placeholder}
                     onChange={(e) => handleChange(e.currentTarget.value)}
                     disabled={props.disabled}
-                    isInvalid={!!isInvalid}
+                    isInvalid={isInvalid}
                 />
             </Form.Group>
             <div className="remaining-controls-group">

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -277,10 +277,8 @@ export const SingleInputFormShowRemaining: React.FC<SingleInputFormShowRemaining
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
-        if (!isInvalid) {
-            props.onSubmit(props.value)
-            props.onChangeValue('')
-        }
+        props.onSubmit(props.value)
+        props.onChangeValue('')
     }
     const handleChange = (newValue: string) => {
         props.onChangeValue(newValue);
@@ -308,7 +306,7 @@ export const SingleInputFormShowRemaining: React.FC<SingleInputFormShowRemaining
             </Form.Group>
             <div className="remaining-controls-group">
                 <span className={isInvalid ? 'text-danger' : undefined}>{feedbackText}</span>
-                <Button bsPrefix={buttonClass} type='submit' disabled={props.disabled}>{props.children}</Button>
+                <Button bsPrefix={buttonClass} type='submit' disabled={props.disabled || isInvalid}>{props.children}</Button>
             </div>
         </Form>
     )

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -478,6 +478,10 @@ h3.alert-heading {
 	border: 1px solid #cecbc9;
 }
 
+.form-control-remaining.is-invalid {
+	background-image: none;
+}
+
 .remaining-controls-group {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
This PR modifies the existing `SingleInputFormShowRemaining` component to make the form field outline and the color of the remaining characters text red when the user's entry is over the limit. The red in use is [the `danger` Bootstrap color](https://getbootstrap.com/docs/4.0/getting-started/theming/#theme-colors), which seems to have [just above a 4.5 contrast ratio with white](https://contrast-ratio.com/#rgb%28220%2C%2053%2C%2069%29-on-white). The "Change" button is disabled if the entry is over the limit, and I changed `main.css` to remove the default "X" from the description form when it is invalid. Additionally, I changed some code to use more React Bootstrap components, modified the remaining characters text for clarity, added some spaces after edit icons (following patterns seen elsewhere), and re-organized imports in `common.tsx`. Feedback on anything is welcome. The PR aims to resolve issue #111.

Example:
<img width="600" alt="Screen Shot 2020-08-05 at 9 47 26 AM" src="https://user-images.githubusercontent.com/35741256/89420767-2c83dd80-d701-11ea-9303-d2f8d60e643e.png">