### PR TITLE
Update user Web socket error source name on Queue page (#116)

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -264,11 +264,11 @@ export function QueuePage(props: PageProps<QueuePageParams>) {
     //Render
     const isChanging = joinQueueLoading || leaveQueueLoading || leaveAndJoinQueueLoading || changeAgendaLoading;
     const errorSources = [
-        {source: 'Queue Connection', error: queueWebSocketError}, 
-        {source: 'Join Queue', error: joinQueueError}, 
-        {source: 'Leave Queue', error: leaveQueueError}, 
-        {source: 'Refresh My User', error: userWebSocketError}, 
-        {source: 'Leave and Join Queue', error: leaveAndJoinQueueError}, 
+        {source: 'Queue Connection', error: queueWebSocketError},
+        {source: 'Join Queue', error: joinQueueError},
+        {source: 'Leave Queue', error: leaveQueueError},
+        {source: 'User Connection', error: userWebSocketError},
+        {source: 'Leave and Join Queue', error: leaveAndJoinQueueError},
         {source: 'Change Agenda', error: changeAgendaError}
     ].filter(e => e.error) as FormError[];
     const loginDialogVisible = errorSources.some(checkForbiddenError);


### PR DESCRIPTION
This PR updates the error source name for `userWebSocketError` to "User Connection" on the queue page, which is what it is on the home page. It could (but might not) make sense to refactor the `errorSources` generation and the `FormError` type eventually to use an enumeration or some other data structure (to help avoid these error source names getting out of sync), but I think we all have bigger fish to fry at the moment. The PR aims to resolve issue #116.