### PR TITLE
Fix Queue.NotFoundError in QueueConsumer upon Queue Delete when Attendee Exists

### DIFF
--- a/src/officehours_api/consumers.py
+++ b/src/officehours_api/consumers.py
@@ -71,7 +71,13 @@ class QueueConsumer(JsonWebsocketConsumer):
         )
 
     def queue_update(self, event):
-        queue = Queue.objects.get(pk=self.queue_id)
+        try:
+            queue = Queue.objects.get(pk=self.queue_id)
+        except Queue.DoesNotExist:
+            self.send_json({
+                'type': 'deleted',
+            })
+            return
         QueueSerializer = (
             QueueHostSerializer
             if is_host(self.user, queue)


### PR DESCRIPTION
This happened because Queue.delete triggers Meeting.delete, which manually triggers the m2m signals via manual save. The signals trigger QueueConsumer to issue an update, which tries to query the queue which has already been deleted. There might be a more elegant fix than this (a way to remove the manual m2m signal trigger without breaking any functionality?), but this seems to get the job done without side-effects.

Closes #118 