### PR TITLE
Quick fix for UsersConsumer slowness

### DIFF
--- a/src/assets/src/components/edit.tsx
+++ b/src/assets/src/components/edit.tsx
@@ -538,10 +538,10 @@ export function QueueEditorPage(props: PageProps<EditPageParams>) {
         {source: 'Allowed Meeting Types', error: updateAllowedMeetingTypesError}
     ].filter(e => e.error) as FormError[];
     const loginDialogVisible = errorSources.some(checkForbiddenError);
-    const loadingDisplay = <LoadingDisplay loading={isChanging}/>
+    const loadingDisplay = <LoadingDisplay loading={isChanging || !users}/>
     const errorDisplay = <ErrorDisplay formErrors={errorSources}/>
     const queueEditor = queue
-        && <QueueEditor queue={queue}  disabled={isChanging} user={props.user!}
+        && <QueueEditor queue={queue}  disabled={isChanging || !users} user={props.user!}
             backends={props.backends} defaultBackend={props.defaultBackend}
             onAddHost={doAddHost} onRemoveHost={confirmRemoveHost} 
             onAddMeeting={doAddMeeting} onRemoveMeeting={confirmRemoveMeeting} 

--- a/src/officehours_api/consumers.py
+++ b/src/officehours_api/consumers.py
@@ -13,7 +13,8 @@ from safedelete.signals import post_softdelete
 from officehours_api.models import Queue, Meeting, Profile
 from officehours_api.permissions import is_host
 from officehours_api.serializers import (
-    QueueHostSerializer, QueueAttendeeSerializer, UserSerializer
+    QueueHostSerializer, QueueAttendeeSerializer, UserSerializer,
+    NestedUserSerializer
 )
 
 
@@ -154,7 +155,7 @@ class UsersConsumer(JsonWebsocketConsumer):
 
     def _get_users(self):
         return list(
-            UserSerializer(u, context={'user': self.user}).data
+            NestedUserSerializer(u).data
             for u in User.objects.all()
         )
 


### PR DESCRIPTION
Use `NestedUserSerializer` and disable/show spinner on `/edit` while `users` aren't yet loaded