### PR TITLE
Remove self-focusing code from AddAttendeeForm (#138)

### DIFF
--- a/src/assets/src/components/edit.tsx
+++ b/src/assets/src/components/edit.tsx
@@ -107,10 +107,6 @@ function AddAttendeeForm(props: AddAttendeeFormProps) {
             ? props.defaultBackend
             : Array.from(props.allowedBackends)[0]
     );
-    const inputRef = createRef<HTMLInputElement>();
-    useEffect(() => {
-        inputRef.current!.focus();
-    }, []);
     const submit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         props.onSubmit(attendee, selectedBackend);
@@ -121,7 +117,7 @@ function AddAttendeeForm(props: AddAttendeeFormProps) {
     return (
         <form onSubmit={submit} className="input-group">
             <input onChange={(e) => setAttendee(e.target.value)} value={attendee}
-                ref={inputRef} type="text" className="form-control" placeholder="Uniqname..."
+                type="text" className="form-control" placeholder="Uniqname..."
                 disabled={props.disabled} id="add_attendee" />
             <div className="input-group-append">
                 <MeetingBackendSelector options={options} defaultBackend={props.defaultBackend}

--- a/src/assets/src/components/edit.tsx
+++ b/src/assets/src/components/edit.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState, createRef, ChangeEvent, useEffect } from "react";
+import { useState, createRef, ChangeEvent } from "react";
 import { Link } from "react-router-dom";
 import * as ReactGA from "react-ga";
 import { Modal, Button, Table, Alert, Form } from "react-bootstrap";


### PR DESCRIPTION
This PR removes self-focusing code from the `AddAttendeeForm` component, which was causing this field to be highlighted on initial load (this may be hard to see in deployed applications because of page loading). The PR aims to resolve issue #138.