### PR TITLE
 Right-align navigation bar dropdown (#119)

### DIFF
--- a/src/officehours_ui/templates/base.html
+++ b/src/officehours_ui/templates/base.html
@@ -51,7 +51,7 @@
                 <a class="nav-link dropdown-toggle" href="#" id="userMenu" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   {{ request.user.username }}
                 </a>
-                <div class="dropdown-menu" aria-labelledby="userMenu">
+                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userMenu">
                   <a class="dropdown-item" href="{% url 'manage' %}" style="background-color: white; color:#212529">
                     Manage Queues
                   </a>


### PR DESCRIPTION
This PR adds a Bootstrap class to the navigation drop-down menu in the base.html template so that it extends left into the page instead of right (and off the page at some widths, zoom levels). The PR aims to resolve issue #119.