### PR TITLE
Validate Uniqname via API Call

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -148,11 +148,6 @@ export const SingleInputForm: React.FC<SingleInputFormProps> = (props) => {
     );
 }
 
-
-export const invalidUniqnameMessage = (uniqname: string) =>
-    uniqname + " is not a valid user. Please make sure the uniqname is correct, and that they have logged onto Remote Office Hours Queue at least once."
-
-
 interface DateDisplayProps {
     date: string;
 }

--- a/src/assets/src/components/edit.tsx
+++ b/src/assets/src/components/edit.tsx
@@ -10,7 +10,7 @@ import * as api from "../services/api";
 import { User, QueueHost, Meeting, BluejeansMetadata, isQueueHost, QueueAttendee } from "../models";
 import { UserDisplay, RemoveButton, ErrorDisplay, FormError, checkForbiddenError, LoadingDisplay, SingleInputForm, DateDisplay, CopyField, EditToggleField, LoginDialog, Breadcrumbs, DateTimeDisplay, BlueJeansDialInMessage, ShowRemainingField, BackendSelector as MeetingBackendSelector, DropdownValue } from "./common";
 import { usePromise } from "../hooks/usePromise";
-import { redirectToLogin, sanitizeUniqname, validateAndFetchUserByUniqname, redirectToSearch } from "../utils";
+import { redirectToLogin, sanitizeUniqname, validateAndFetchUser, redirectToSearch } from "../utils";
 import { PageProps } from "./page";
 import { useQueueWebSocket } from "../services/sockets";
 
@@ -444,7 +444,7 @@ export function QueueEditorPage(props: PageProps<EditPageParams>) {
     }
     const addHost = async (uniqname: string) => {
         uniqname = sanitizeUniqname(uniqname);
-        const user = await validateAndFetchUserByUniqname(uniqname);
+        const user = await validateAndFetchUser(uniqname);
         recordQueueManagementEvent("Added Host");
         await api.addHost(queue!.id, user.id);
     }
@@ -459,7 +459,7 @@ export function QueueEditorPage(props: PageProps<EditPageParams>) {
     }
     const addMeeting = async (uniqname: string, backend: string) => {
         uniqname = sanitizeUniqname(uniqname);
-        const user = await validateAndFetchUserByUniqname(uniqname);
+        const user = await validateAndFetchUser(uniqname);
         recordQueueManagementEvent("Added Meeting");
         await api.addMeeting(queue!.id, user.id, backend);
     }

--- a/src/assets/src/services/api.ts
+++ b/src/assets/src/services/api.ts
@@ -180,17 +180,11 @@ export const setStatus = async (queue_id: number, open: boolean) => {
     return await resp.json();
 }
 
-const getUser = async (identifier: number | string) => {
-    const resp = await fetch(`/api/users/${identifier}/`, { method: "GET" });
+export const getUser = async (id_or_username: number | string) => {
+    const resp = await fetch(`/api/users/${id_or_username}/`, { method: "GET" });
     await handleErrors(resp);
     return await resp.json() as User | MyUser;
 }
-
-export const getUserById = async (user_id: number) =>
-    getUser(user_id);
-
-export const getUserByUniqname = async (uniqname: string) =>
-    getUser(uniqname);
 
 export const updateUser = async (user_id: number, phone_number: string) => {
     const resp = await fetch(`/api/profiles/${user_id}/`, {

--- a/src/assets/src/services/sockets.ts
+++ b/src/assets/src/services/sockets.ts
@@ -16,13 +16,6 @@ export const useQueueWebSocket = (queue_id: number, onUpdate: (q: QueueHost | Qu
     );
 }
 
-export const useUsersWebSocket = (onUpdate: (users: User[]) => void) => {
-    return useWebSocket(
-        `${getProtocol()}//${location.host}/ws/users/`,
-        onUpdate,
-    );
-}
-
 export const useUserWebSocket = (user_id: number | undefined, onUpdate: (user: User | MyUser) => void) => {
     return typeof user_id === "number"
         ? useWebSocket(

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -1,5 +1,5 @@
 import * as ReactGA from "react-ga";
-import { getUserByUniqname } from "./services/api";
+import { getUser } from "./services/api";
 
 export const redirectToLogin = (loginUrl: string) => {
     ReactGA.event({
@@ -22,12 +22,12 @@ export const redirectToSearch = (term: string) => {
 const invalidUniqnameMessage = (uniqname: string) =>
     uniqname + " is not a valid user. Please make sure the uniqname is correct, and that they have logged onto Remote Office Hours Queue at least once."
 
-export const validateAndFetchUserByUniqname = async (uniqname: string) => {
+export const validateAndFetchUser = async (uniqname: string) => {
     if (uniqname.length < 3) throw new Error("Uniqnames must be at least 3 characters long.");
     if (uniqname.length > 8) throw new Error("Uniqnames must be at most 8 characters long.");
     if (!uniqname.match(/^[a-z]+$/i)) throw new Error("Uniqnames cannot contain non-alphanumeric characters.");
     try {
-        return await getUserByUniqname(uniqname);
+        return await getUser(uniqname);
     } catch (err) {
         throw err.name === "NotFoundError"
             ? new Error(invalidUniqnameMessage(uniqname))

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -1,4 +1,5 @@
 import * as ReactGA from "react-ga";
+import { getUserByUniqname } from "./services/api";
 
 export const redirectToLogin = (loginUrl: string) => {
     ReactGA.event({
@@ -18,10 +19,20 @@ export const redirectToSearch = (term: string) => {
     location.href = `/search/${term}/?redirected=true`;
 }
 
-export const validateUniqname = (uniqname: string) => {
+const invalidUniqnameMessage = (uniqname: string) =>
+    uniqname + " is not a valid user. Please make sure the uniqname is correct, and that they have logged onto Remote Office Hours Queue at least once."
+
+export const validateAndFetchUserByUniqname = async (uniqname: string) => {
     if (uniqname.length < 3) throw new Error("Uniqnames must be at least 3 characters long.");
     if (uniqname.length > 8) throw new Error("Uniqnames must be at most 8 characters long.");
     if (!uniqname.match(/^[a-z]+$/i)) throw new Error("Uniqnames cannot contain non-alphanumeric characters.");
+    try {
+        return await getUserByUniqname(uniqname);
+    } catch (err) {
+        throw err.name === "NotFoundError"
+            ? new Error(invalidUniqnameMessage(uniqname))
+            : err;
+    }
 }
 
 export const sanitizeUniqname = (unsanitized: string) => {

--- a/src/officehours_api/consumers.py
+++ b/src/officehours_api/consumers.py
@@ -239,6 +239,7 @@ def trigger_user_deleted(sender, instance: User, **kwargs):
 @receiver(post_save, sender=Profile)
 @receiver(post_delete, sender=Profile)
 def trigger_user_update_for_profile(sender, instance: Profile, **kwargs):
+    # Get user_id before commit in case user is deleted
     user_id = instance.user.id
     transaction.on_commit(lambda: send_user_update(user_id))
 

--- a/src/officehours_api/consumers.py
+++ b/src/officehours_api/consumers.py
@@ -239,7 +239,8 @@ def trigger_user_deleted(sender, instance: User, **kwargs):
 @receiver(post_save, sender=Profile)
 @receiver(post_delete, sender=Profile)
 def trigger_user_update_for_profile(sender, instance: Profile, **kwargs):
-    transaction.on_commit(lambda: send_user_update(instance.user.id))
+    user_id = instance.user.id
+    transaction.on_commit(lambda: send_user_update(user_id))
 
 
 @receiver(m2m_changed, sender=User.meeting_set.through)

--- a/src/officehours_api/consumers.py
+++ b/src/officehours_api/consumers.py
@@ -239,7 +239,7 @@ def trigger_user_deleted(sender, instance: User, **kwargs):
 @receiver(post_save, sender=Profile)
 @receiver(post_delete, sender=Profile)
 def trigger_user_update_for_profile(sender, instance: Profile, **kwargs):
-    # Get user_id before commit in case user is deleted
+    # Get user_id before commit in case user or profile are deleted or unlinked
     user_id = instance.user.id
     transaction.on_commit(lambda: send_user_update(user_id))
 

--- a/src/officehours_api/permissions.py
+++ b/src/officehours_api/permissions.py
@@ -3,15 +3,6 @@ from rest_framework import permissions
 from .models import Queue, Meeting, Profile
 
 
-class IsCurrentUser(permissions.BasePermission):
-    '''
-    Custom permission to only allow users to view themselves.
-    '''
-
-    def has_object_permission(self, request, view, obj: User):
-        return obj == request.user
-
-
 class IsCurrentProfile(permissions.BasePermission):
     def has_object_permission(self, request, view, obj: Profile):
         return obj.user == request.user

--- a/src/officehours_api/routing.py
+++ b/src/officehours_api/routing.py
@@ -5,5 +5,4 @@ from . import consumers
 websocket_urlpatterns = [
     re_path(r'ws/queues/(?P<queue_id>\w+)/$', consumers.QueueConsumer),
     re_path(r'ws/users/(?P<user_id>\w+)/$', consumers.UserConsumer),
-    re_path(r'ws/users/$', consumers.UsersConsumer),
 ]

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -78,7 +78,7 @@ class NestedAttendeeSerializer(serializers.ModelSerializer):
         fields = ['id', 'user_id', 'username', 'first_name', 'last_name']
 
 
-class UserListSerializer(serializers.ModelSerializer):
+class ShallowUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['id', 'username', 'first_name', 'last_name']

--- a/src/officehours_api/urls.py
+++ b/src/officehours_api/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('', views.api_root, name='api-root'),
     path('users/', views.UserList.as_view(), name='user-list'),
     path('users/<int:pk>/', views.UserDetail.as_view(), name='user-detail'),
+    path('users/<str:username>/', views.UserUniqnameDetail.as_view(), name='user-uniqname-detail'),
     path('queues/', views.QueueList.as_view(), name='queue-list'),
     path('queues/<int:pk>/', views.QueueDetail.as_view(), name='queue-detail'),
     path('queues/<int:pk>/hosts/<int:user_id>/', views.QueueHostDetail.as_view(), name='queuehost-detail'),

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -13,11 +13,11 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from officehours_api.models import Queue, Meeting, Attendee, Profile
 from officehours_api.serializers import (
-    UserListSerializer, UserSerializer, QueueAttendeeSerializer,
+    ShallowUserSerializer, UserSerializer, QueueAttendeeSerializer,
     QueueHostSerializer, MeetingSerializer, AttendeeSerializer, ProfileSerializer,
 )
 from officehours_api.permissions import (
-    IsCurrentUser, IsHostOrReadOnly, IsHostOrAttendee, is_host, IsCurrentProfile
+    IsHostOrReadOnly, IsHostOrAttendee, is_host, IsCurrentProfile
 )
 
 
@@ -50,13 +50,24 @@ class DecoupledContextMixin:
 
 class UserList(DecoupledContextMixin, generics.ListAPIView):
     queryset = User.objects.all()
-    serializer_class = UserListSerializer
+    serializer_class = ShallowUserSerializer
 
 
 class UserDetail(DecoupledContextMixin, generics.RetrieveAPIView):
     queryset = User.objects.all()
-    serializer_class = UserSerializer
-    permission_classes = (IsAuthenticated, IsCurrentUser,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, *args, **kwargs):
+        user = self.get_object()
+        if user == request.user:
+            serializer = UserSerializer(user, context={'user': request.user})
+        else:
+            serializer = ShallowUserSerializer(user, context={'user': request.user})
+        return Response(serializer.data)
+
+
+class UserUniqnameDetail(UserDetail):
+    lookup_field = 'username'
 
 
 class QueueList(DecoupledContextMixin, LoggingMixin, generics.ListCreateAPIView):
@@ -110,7 +121,7 @@ class QueueHostDetail(DecoupledContextMixin, LoggingMixin, APIView):
         except ObjectDoesNotExist:
             return Response({'detail': 'Host not found.'}, status=status.HTTP_404_NOT_FOUND)
 
-        serializer = UserListSerializer(host, context={'user': request.user})
+        serializer = ShallowUserSerializer(host, context={'user': request.user})
         return Response(serializer.data)
 
     def post(self, request, pk, user_id, format=None):
@@ -118,7 +129,7 @@ class QueueHostDetail(DecoupledContextMixin, LoggingMixin, APIView):
         self.check_queue_permission(request, queue)
         host = get_object_or_404(User, pk=user_id)
         queue.hosts.add(host)
-        serializer = UserListSerializer(host, context={'user': request.user})
+        serializer = ShallowUserSerializer(host, context={'user': request.user})
         return Response(serializer.data)
 
     def delete(self, request, pk, user_id, format=None):
@@ -156,6 +167,7 @@ class AttendeeList(DecoupledContextMixin, generics.ListAPIView):
 class AttendeeDetail(DecoupledContextMixin, generics.RetrieveAPIView):
     queryset = Attendee.objects.all()
     serializer_class = AttendeeSerializer
+
 
 class ProfileDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Profile.objects.all()


### PR DESCRIPTION
I solved this problem in a more minimal way than I originally described in the linked issue: instead of creating a "search users" API endpoint, I simply allowed the existing `/users/<id>` endpoint to also accept `/users/<uniqname>`, and used that to validate the existence of a uniqname and lookup the user ID.

Closes #141 