### PR TITLE
Add missing QuerySet import

### DIFF
--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -2,6 +2,7 @@ from typing import TypedDict, Literal
 
 from rest_framework import serializers
 from django.contrib.auth.models import User
+from django.db.models import QuerySet
 from officehours_api.models import Queue, Meeting, Attendee, Profile
 
 


### PR DESCRIPTION
This PR adds a missing import for something that I introduced in #153 and that I discovered when poking around `serializers.py`. I guess Python doesn't care that `QuerySet` isn't defined if it's being used as a type hint? I figured I'd correct it.