### PR TITLE
Fold profile API into user API

### DIFF
--- a/src/assets/src/components/preferences.tsx
+++ b/src/assets/src/components/preferences.tsx
@@ -134,7 +134,7 @@ export function PreferencesPage(props: PageProps) {
     // Setup interactions
     const [doUpdateInfo, updateInfoLoading, updateInfoError] = usePromise(
         (phoneNumber, notifyMeAttendee, notifyMeHost) =>
-            api.updateProfile(userId, phoneNumber, notifyMeAttendee, notifyMeHost) as Promise<MyUser>, setUser
+            api.updateUser(userId, phoneNumber, notifyMeAttendee, notifyMeHost) as Promise<MyUser>, setUser
     );
 
     // Render

--- a/src/assets/src/services/api.ts
+++ b/src/assets/src/services/api.ts
@@ -189,8 +189,8 @@ export const getUser = async (id_or_username: number | string) => {
     return await resp.json() as User | MyUser;
 }
 
-export const updateProfile = async (user_id: number, phone_number: string, notify_me_attendee: boolean, notify_me_host: boolean) => {
-    const resp = await fetch(`/api/profiles/${user_id}/`, {
+export const updateUser = async (user_id: number, phone_number: string, notify_me_attendee: boolean, notify_me_host: boolean) => {
+    const resp = await fetch(`/api/users/${user_id}/`, {
         method: "PATCH",
         headers: getPatchHeaders(),
         body: JSON.stringify({

--- a/src/officehours_api/permissions.py
+++ b/src/officehours_api/permissions.py
@@ -3,11 +3,6 @@ from rest_framework import permissions
 from .models import Queue, Meeting, Profile
 
 
-class IsCurrentProfile(permissions.BasePermission):
-    def has_object_permission(self, request, view, obj: Profile):
-        return obj.user == request.user
-
-
 def is_host(user: User, queue: Queue):
     return (
         user.is_superuser

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -87,7 +87,7 @@ class MyUserSerializer(serializers.ModelSerializer):
             'id', 'username', 'email', 'first_name', 'last_name', 'my_queue',
             'hosted_queues', 'phone_number', 'notify_me_attendee', 'notify_me_host'
         ]
-    
+
     def get_my_queue(self, obj):
         try:
             meeting = obj.meeting_set.get()

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -74,6 +74,7 @@ class MyUserSerializer(serializers.ModelSerializer):
     context: UserContext
 
     username = serializers.CharField(read_only=True)
+    email = serializers.CharField(read_only=True)
     my_queue = serializers.SerializerMethodField(read_only=True)
     hosted_queues = serializers.SerializerMethodField(read_only=True)
     phone_number = serializers.CharField(source='profile.phone_number', allow_blank=True)

--- a/src/officehours_api/urls.py
+++ b/src/officehours_api/urls.py
@@ -16,7 +16,6 @@ urlpatterns = [
     path('meetings/<int:pk>/', views.MeetingDetail.as_view(), name='meeting-detail'),
     path('attendees/', views.AttendeeList.as_view(), name='attendee-list'),
     path('attendees/<int:pk>/', views.AttendeeDetail.as_view(), name='attendee-detail'),
-    path('profiles/<int:pk>/', views.ProfileDetail.as_view(), name='profile-detail'),
 ]
 
 if settings.DEBUG:

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -17,7 +17,7 @@ from officehours_api.serializers import (
     QueueHostSerializer, MeetingSerializer, AttendeeSerializer,
 )
 from officehours_api.permissions import (
-    IsHostOrReadOnly, IsHostOrAttendee, is_host, IsCurrentProfile
+    IsHostOrReadOnly, IsHostOrAttendee, is_host,
 )
 
 

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -57,7 +57,7 @@ class UserDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdateAPI
     queryset = User.objects.all()
     permission_classes = (IsAuthenticated,)
 
-    def get_serializer(self, instance, data=None, many=None, partial=None):
+    def get_serializer(self, instance=None, data=None, many=None, partial=None):
         ctx = self.get_serializer_context()
         kwargs = {}
         if data:
@@ -80,7 +80,7 @@ class UserDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdateAPI
     def partial_update(self, request, *args, **kwargs):
         user = self.get_object()
         self.check_change_permission(request, user)
-        return super().update(request, *args, **kwargs)
+        return super().partial_update(request, *args, **kwargs)
 
 
 class UserUniqnameDetail(UserDetail):

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -72,7 +72,7 @@ class UserDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdateAPI
         if user != request.user:
             self.permission_denied(request)
 
-    def update(self, request, pk, *args, **kwargs):
+    def update(self, request, *args, **kwargs):
         user = self.get_object()
         self.check_change_permission(request, user)
         return super().update(request, *args, **kwargs)


### PR DESCRIPTION
Fixes #179 
Having the users and profile APIs separate added some complications to how they were read and updated, so I decided to roll them both into one. Narrowing the API surface seemed like a generally good idea. Fields that a user shouldn't be able to modify, like email, have been made read-only.