### PR TITLE
Improve validation patterns in, accessibility of form components (#159, #183)

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -193,7 +193,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
                     <EditToggleField
                         id='agenda'
                         value={agendaText}
-                        formLabel='Meeting agenda'
+                        formLabel='Meeting Agenda'
                         placeholder=''
                         buttonOptions={{ onSubmit: props.onChangeAgenda, buttonType: 'success' }}
                         disabled={props.disabled}

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -180,7 +180,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
             {closedAlert}
             {alert}
             <h3>You are currently in line.</h3>
-            <Card bsPrefix='card card-middle card-width center-align'>
+            <Card className='card-middle card-width center-align'>
                 <Card.Body>
                     <Card.Text>Your number in line: <strong>{props.queue.my_meeting!.line_place + 1}</strong></Card.Text>
                     <Card.Text>Time Joined: <strong><DateTimeDisplay dateTime={props.queue.my_meeting!.created_at}/></strong></Card.Text>
@@ -193,10 +193,10 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
                     <EditToggleField
                         id='agenda'
                         value={agendaText}
+                        formLabel='Meeting agenda'
                         placeholder=''
-                        buttonType='success'
+                        buttonOptions={{ onSubmit: props.onChangeAgenda, buttonType: 'success' }}
                         disabled={props.disabled}
-                        onSubmit={props.onChangeAgenda}
                         fieldComponent={StatelessInputGroupForm}
                         fieldSchema={meetingAgendaSchema}
                         showRemaining={true}

--- a/src/assets/src/components/queueEditors.tsx
+++ b/src/assets/src/components/queueEditors.tsx
@@ -49,20 +49,20 @@ export function GeneralEditor(props: GeneralEditorProps) {
             <StatelessInputGroupForm
                 id='name'
                 value={props.name}
+                formLabel='Queue name'
                 placeholder='Queue name...'
                 disabled={props.disabled}
-                isInvalid={props.nameValidationResult ? props.nameValidationResult.isInvalid : undefined}
-                feedbackMessages={props.nameValidationResult ? props.nameValidationResult.messages : []}
+                validationResult={props.nameValidationResult}
                 onChangeValue={props.onChangeName}
             />
             <h3>Description</h3>
             <StatelessTextAreaForm
                 id='description'
                 value={props.description}
+                formLabel='Queue description'
                 placeholder='Queue description...'
                 disabled={props.disabled}
-                isInvalid={props.descriptValidationResult ? props.descriptValidationResult.isInvalid : undefined}
-                feedbackMessages={props.descriptValidationResult ? props.descriptValidationResult.messages : []}
+                validationResult={props.descriptValidationResult}
                 onChangeValue={props.onChangeDescription}
             />
             <h3>Meeting Types {requiredSymbol}</h3>
@@ -104,6 +104,10 @@ export function ManageHostsEditor(props: ManageHostsEditorProps) {
         </ListGroup.Item>
     ));
 
+    const handleSubmit = (username: string) => {
+        if (!hostUsernames.includes(username)) props.onAddHost(username);
+    }
+
     return (
         <div>
             <h2>Manage Hosts</h2>
@@ -114,13 +118,9 @@ export function ManageHostsEditor(props: ManageHostsEditorProps) {
             <SingleInputField
                 id="add_host"
                 fieldComponent={StatelessInputGroupForm}
+                formLabel='Add Host'
                 placeholder="Uniqname..."
-                buttonType='success'
-                onSubmit={(username) => {
-                    if (!hostUsernames.includes(username)) {
-                        props.onAddHost(username);
-                    }
-                }}
+                buttonOptions={{ onSubmit: handleSubmit, buttonType: 'success' }}
                 disabled={props.disabled}
                 fieldSchema={uniqnameSchema}
                 showRemaining={false}

--- a/src/assets/src/components/queueEditors.tsx
+++ b/src/assets/src/components/queueEditors.tsx
@@ -49,7 +49,7 @@ export function GeneralEditor(props: GeneralEditorProps) {
             <StatelessInputGroupForm
                 id='name'
                 value={props.name}
-                formLabel='Queue name'
+                formLabel='Queue Name'
                 placeholder='Queue name...'
                 disabled={props.disabled}
                 validationResult={props.nameValidationResult}
@@ -59,7 +59,7 @@ export function GeneralEditor(props: GeneralEditorProps) {
             <StatelessTextAreaForm
                 id='description'
                 value={props.description}
-                formLabel='Queue description'
+                formLabel='Queue Description'
                 placeholder='Queue description...'
                 disabled={props.disabled}
                 validationResult={props.descriptValidationResult}


### PR DESCRIPTION
This PR modifies `SingleInputField`, the stateless form components, and `AddAttendeeForm` to include `formLabel`s for accessibility (#159) and use updated validation patterns (#183). Additional tweaks include the replacement where possible of `bsPrefix` with `className` (`react-bootstrap` recommends avoiding `bsPrefix`) and modifying the spacing of items in the Meeting Actions column in `queueManager.tsx`. The PR aims to resolve issues #159 and #183.