### PR TITLE
Create custom validation hooks (#188)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -6,8 +6,10 @@ import { faSyncAlt, faClipboard, faClipboardCheck, faPencilAlt, faTrashAlt, faHo
 import { Alert, Badge, Breadcrumb, Button, Form, InputGroup, Modal, Table } from "react-bootstrap";
 import Dialog from "react-bootstrap-dialog";
 import { StringSchema } from "yup";
+
+import { useStringValidation } from "../hooks/useValidation";
 import { QueueAttendee, QueueBase, User } from "../models";
-import { validateAndSetStringResult, ValidationResult } from "../validation";
+import { ValidationResult } from "../validation";
 
 type BootstrapButtonTypes = "info" | "warning" | "success" | "primary" | "alternate" | "danger";
 
@@ -335,15 +337,13 @@ interface SingleInputFieldProps {
 // Stateful wrapper for one text input field and associated feedback
 export const SingleInputField: React.FC<SingleInputFieldProps> = (props) => {
     const [value, setValue] = useState(props.value ? props.value : '');
-    const [validationResult, setValidationResult] = useState(undefined as undefined | ValidationResult);
+    const [validationResult, validateAndSetResult, clearResult] = useStringValidation(props.fieldSchema, !!props.showRemaining);
 
     const handleSubmit = (newValue: string) => {
-        const curValidationResult = !validationResult
-            ? validateAndSetStringResult(newValue, props.fieldSchema, setValidationResult, !!props.showRemaining)
-            : validationResult;
+        const curValidationResult = !validationResult ? validateAndSetResult(newValue) : validationResult;
         if (!curValidationResult.isInvalid) {
             props.buttonOptions.onSubmit(newValue);
-            setValidationResult(undefined);
+            clearResult();
             setValue('');
             if (props.onSuccess) props.onSuccess();
         }
@@ -351,7 +351,7 @@ export const SingleInputField: React.FC<SingleInputFieldProps> = (props) => {
 
     const handleChange = (value: string) => {
         setValue(value);
-        validateAndSetStringResult(value, props.fieldSchema, setValidationResult, !!props.showRemaining);
+        validateAndSetResult(value);
     };
 
     return (

--- a/src/assets/src/hooks/useValidation.ts
+++ b/src/assets/src/hooks/useValidation.ts
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { StringSchema } from "yup";
+
+import { QueueHost } from "../models";
+import { 
+    MeetingTypesValidationResult, validateMeetingTypes, validateString, ValidationResult
+} from "../validation";
+
+
+export function useStringValidation (schema: StringSchema, showRemaining?: boolean):
+    [undefined | ValidationResult, (value: string) => ValidationResult, () => void]
+{
+    const [validationResult, setValidationResult] = useState(undefined as undefined | ValidationResult);
+    const validateAndSetResult = (newValue: string) => {
+        const result = validateString(newValue, schema, !!showRemaining);
+        setValidationResult(result);
+        return result;
+    }
+    const clearResult = () => setValidationResult(undefined);
+    return [validationResult, validateAndSetResult, clearResult];
+}
+
+export function useMeetingTypesValidation (queue?: QueueHost):
+    [undefined | MeetingTypesValidationResult, (value: Set<string>) => MeetingTypesValidationResult, () => void]
+{
+    const [validationResult, setValidationResult] = useState(undefined as undefined | MeetingTypesValidationResult);
+    const validateAndSetResult = (newValue: Set<string>) => {
+        const result = validateMeetingTypes(newValue, queue);
+        setValidationResult(result);
+        return result;
+    }
+    const clearResult = () => setValidationResult(undefined);
+    return [validationResult, validateAndSetResult, clearResult];
+}

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -25,7 +25,7 @@ function createRemainingCharsMessage (data: { max: number; } & Partial<TestMessa
 const createInvalidUniqnameMessage = (uniqname: string) => (
     uniqname + " is not a valid user. " +
     "Please make sure the uniqname is correct, and that they have logged onto Remote Office Hours Queue at least once."
-)
+);
 
 export const confirmUserExists = async (uniqname: string) => {
     const sanitizedUniqname = uniqname.trim().toLowerCase();
@@ -72,7 +72,7 @@ export function validateString (value: string, schema: StringSchema, showRemaini
     let isInvalid = false;
     let messages = Array();
     try {
-        transformedValue = schema.validateSync(value)
+        transformedValue = schema.validateSync(value);
         const maxLimit = getMaxLimit(schema.describe());
         if (showRemaining && maxLimit) {
             messages.push(createRemainingCharsMessage({'value': transformedValue, 'max': maxLimit}));

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -112,28 +112,3 @@ export function validateMeetingTypes (value: Set<string>, queue?: QueueHost): Me
     }
     return { isInvalid: (noTypesSelected || existingMeetingConflict), messages: messages };
 }
-
-
-// Utility wrappers for both validating and updating React state using hook setter functions
-
-type StringValidationResultSetter = React.Dispatch<React.SetStateAction<undefined | ValidationResult>>;
-type MeetingTypesValidationResultSetter = React.Dispatch<React.SetStateAction<undefined | MeetingTypesValidationResult>>;
-
-export function validateAndSetStringResult (
-    someValue: string,
-    schema: StringSchema,
-    resultSetter: StringValidationResultSetter,
-    showRemaining?: boolean
-): ValidationResult {
-    const validationResult = validateString(someValue, schema, !!showRemaining);
-    resultSetter(validationResult);
-    return validationResult;
-};
-
-export function validateAndSetMeetingTypesResult (
-    allowedBackends: Set<string>, resultSetter: MeetingTypesValidationResultSetter, queue?: QueueHost
-): MeetingTypesValidationResult {
-    const validationResult = validateMeetingTypes(allowedBackends, queue);
-    resultSetter(validationResult);
-    return validationResult;
-};

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -48,7 +48,7 @@ export const validatePhoneNumber = (phone: string, countryDialCode: string): Err
 
 // Schemas
 
-const blankText = 'This field may not be left blank.'
+const blankText = 'This field may not be left blank.';
 
 export const queueNameSchema = string().trim().required(blankText).max(100, createRemainingCharsMessage);
 export const queueDescriptSchema = string().trim().max(1000, createRemainingCharsMessage);
@@ -78,7 +78,7 @@ export function validateString (value: string, schema: StringSchema, showRemaini
             messages.push(createRemainingCharsMessage({'value': transformedValue, 'max': maxLimit}));
         }
     } catch (error) {
-        transformedValue = error.value
+        transformedValue = error.value;
         isInvalid = true;
         messages = error.errors;
     }


### PR DESCRIPTION
This PR refactors the existing `validateAndSet...` wrapper functions as the custom React hooks `useStringValidation` and `useMeetingTypesValidation` and updates usages in several components. The PR attempts to resolve issue #188.