### PR TITLE
Add prompts to enable SMS notifications #182, #184 

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -180,7 +180,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         && (
             <Card.Text>
                 <Alert variant="info">
-                    Did you know? You can receive a SMS (text) message when 
+                    Did you know? You can receive an SMS (text) message when 
                     it's your turn by by adding your cell phone number and 
                     enabling attendee notifications in 
                     your <Link to="/preferences">User Preferences</Link>.

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -175,6 +175,17 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         ? <small className="card-text-spacing meeting-type-message">A Host has been assigned to this meeting. Meeting Type can no longer be changed.</small>
         : <button disabled={props.disabled} onClick={props.onShowDialog} type="button" className="btn btn-link">Change</button>;
     const agendaText = props.queue.my_meeting!.agenda
+    const numberInLine = props.queue.my_meeting!.line_place + 1;
+    const notificationBlurb = numberInLine > 1
+        && (
+            <Card.Text>
+                <Alert variant="info">
+                    If you have opted in to attendee notifications in
+                    your <Link to="/preferences">User Preferences</Link>,
+                    you will get an SMS (text) message when it is your turn.
+                </Alert>
+            </Card.Text>
+        );
     return (
         <>
             {closedAlert}
@@ -182,7 +193,8 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
             <h3>You are currently in line.</h3>
             <Card className='card-middle card-width center-align'>
                 <Card.Body>
-                    <Card.Text>Your number in line: <strong>{props.queue.my_meeting!.line_place + 1}</strong></Card.Text>
+                    <Card.Text>Your number in line: <strong>{numberInLine}</strong></Card.Text>
+                    {notificationBlurb}
                     <Card.Text>Time Joined: <strong><DateTimeDisplay dateTime={props.queue.my_meeting!.created_at}/></strong></Card.Text>
                     <Card.Text>
                         Meeting via: <strong>{props.backends[props.queue.my_meeting!.backend_type]}</strong>

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -180,9 +180,10 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         && (
             <Card.Text>
                 <Alert variant="info">
-                    If you have opted in to attendee notifications in
-                    your <Link to="/preferences">User Preferences</Link>,
-                    you will get an SMS (text) message when it is your turn.
+                    Did you know? You can receive a SMS (text) message when 
+                    it's your turn by by adding your cell phone number and 
+                    enabling attendee notifications in 
+                    your <Link to="/preferences">User Preferences</Link>.
                 </Alert>
             </Card.Text>
         );

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -180,10 +180,12 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         && (
             <Card.Text>
                 <Alert variant="info">
-                    Did you know? You can receive an SMS (text) message when 
-                    it's your turn by by adding your cell phone number and 
-                    enabling attendee notifications in 
-                    your <Link to="/preferences">User Preferences</Link>.
+                    <small>
+                        Did you know? You can receive an SMS (text) message when 
+                        it's your turn by by adding your cell phone number and 
+                        enabling attendee notifications in 
+                        your <Link to="/preferences">User Preferences</Link>.
+                    </small>
                 </Alert>
             </Card.Text>
         );

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -212,7 +212,11 @@ function QueueManager(props: QueueManagerProps) {
             </Table>
         )
         : (
-            <Alert variant="dark">No meetings in queue.</Alert>
+            <Alert variant="dark">
+                No meetings in queue. If you have opted in to host notifications in 
+                your <Link to="/preferences">User Preferences</Link>, you will get an 
+                SMS (text) message when someone joins your empty queue.
+            </Alert>
         );
 
     const currentStatus = props.queue.status === 'open';

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -212,11 +212,13 @@ function QueueManager(props: QueueManagerProps) {
             </Table>
         )
         : (
-            <Alert variant="dark">
-                No meetings in queue. If you have opted in to host notifications in 
-                your <Link to="/preferences">User Preferences</Link>, you will get an 
-                SMS (text) message when someone joins your empty queue.
-            </Alert>
+            <>
+            <hr/>
+            <h5>No meetings in Queue</h5>
+            <p>
+                Did you know? You can get notified by SMS (text) message when someone joins your empty queue by adding your cell phone number and enabling host notifications in your <Link to="/preferences">User Preferences</Link>. 
+            </p>
+            </>
         );
 
     const currentStatus = props.queue.status === 'open';

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -214,7 +214,7 @@ function QueueManager(props: QueueManagerProps) {
         : (
             <>
             <hr/>
-            <h5>No meetings in Queue</h5>
+            <h5>No Meetings in Queue</h5>
             <p>
                 Did you know? You can get notified by SMS (text) message when someone joins your empty queue by adding your cell phone number and enabling host notifications in your <Link to="/preferences">User Preferences</Link>. 
             </p>


### PR DESCRIPTION
Adds text to remind users of the existence of notifications on the queue page and the edit page.

Will rely on @ssciolla's accessibility tweaks to fix the color contrast problem in the `info` alert.

Closes #182, #184 