### PR TITLE
Fix color contrast issues, make other misc. edits (#155)

### DIFF
--- a/src/assets/src/components/home.tsx
+++ b/src/assets/src/components/home.tsx
@@ -9,8 +9,8 @@ import { useUserWebSocket } from "../services/sockets";
 function QueueLookup() {
     const [lookup, setLookup] = useState("");
     return (
-        <form className="form-inline row" method="get" action={"/search/" + lookup}>
-            <div className="input-group page-content-flow col-sm-12 col-md-8 col-lg-6">
+        <form className="form-inline row mt-3" method="get" action={"/search/" + lookup}>
+            <div className="input-group col-sm-12 col-md-8 col-lg-6">
                 <input type="text"
                     required
                     aria-label="Queue name or host uniqname"

--- a/src/assets/src/components/manage.tsx
+++ b/src/assets/src/components/manage.tsx
@@ -22,8 +22,8 @@ function ManageQueueTable(props: ManageQueueTableProps) {
     return (
         <div>
             {queueResults}
-            <div className="page-content-flow">
-                <Link to="/add_queue">
+            <div className="mt-3">
+                <Link to="/add_queue" tabIndex={-1}>
                     <Button variant='success' aria-label='Add Queue'>+ Add Queue</Button>
                 </Link>
             </div>

--- a/src/assets/src/components/queueEditors.tsx
+++ b/src/assets/src/components/queueEditors.tsx
@@ -93,14 +93,19 @@ export function ManageHostsEditor(props: ManageHostsEditorProps) {
     const hostsSoFar = props.hosts.map((host, key) => (
         <ListGroup.Item key={key}>
             <UserDisplay user={host} />
-            <div className='float-right'>
-                <RemoveButton
-                    onRemove={() => props.onRemoveHost(host)}
-                    size='sm'
-                    disabled={props.disabled || host.id === props.currentUser?.id}
-                    screenReaderLabel='Remove Host'
-                />
-            </div>
+            {
+                (host.id !== props.currentUser?.id)
+                    && (
+                        <div className='float-right'>
+                            <RemoveButton
+                                onRemove={() => props.onRemoveHost(host)}
+                                size='sm'
+                                disabled={props.disabled}
+                                screenReaderLabel='Remove Host'
+                            />
+                        </div>
+                    )
+            }
         </ListGroup.Item>
     ));
 
@@ -128,7 +133,10 @@ export function ManageHostsEditor(props: ManageHostsEditorProps) {
                 + Add Host
             </SingleInputField>
             <h3>Current Hosts</h3>
-            <p>To remove a host, select the trash icon to the right of the user's name. You cannot remove yourself as a host.</p>
+            <p>
+                To remove a host, select the trash icon to the right of the user's name.
+                <strong>You cannot remove yourself as a host.</strong>
+            </p>
             <ListGroup>{hostsSoFar}</ListGroup>
         </div>
     );

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -247,8 +247,8 @@ function QueueManager(props: QueueManagerProps) {
                 </Col>
             </Row>
             <Row noGutters className={spacingClass}>
-                <Col md={2}><div id='created-at'>Created At</div></Col>
-                <Col md={6}><div aria-labelledby='created-at'><DateDisplay date={props.queue.created_at}/></div></Col>
+                <Col md={2}><div id='created'>Created</div></Col>
+                <Col md={6}><div aria-labelledby='created'><DateDisplay date={props.queue.created_at}/></div></Col>
             </Row>
             <h2 className={spacingClass}>Meetings in Queue</h2>
             <Row noGutters className={spacingClass}>

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -174,11 +174,11 @@ h3, .h3 {
 }
 
 a:not(.btn), a:link:not(.btn), a:visited:not(.btn) {
-	color: #004a8b;
+	color: #0060ba;
 }
 
 a:hover {
-	color: #004a8b;
+	color: #0060ba;
 }
 
 .bottom-right {

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -181,6 +181,14 @@ a:hover {
 	color: #0060ba;
 }
 
+.alert a {
+	text-decoration: underline;
+}
+
+p a {
+	text-decoration: underline;
+}
+
 .bottom-right {
 	position: fixed;
 	bottom: 0;

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -322,20 +322,20 @@ a.nav-link.disabled:hover, a.nav-link.disabled:active, a.nav-link.disabled:focus
 }
 
 .btn-success {
-    color: #ffffff;
-    background-color: #00820d;
-    border-color: #00820d;
+	color: #ffffff;
+	background-color: #00820d;
+	border-color: #00820d;
 }
 
 .btn-outline-success {
-    border-color: #00820d;
-    color: #00820d;
+	border-color: #00820d;
+	color: #00820d;
 }
 
 .btn-outline-success:hover, .btn-outline-success:focus, .btn-outline-success:active, .btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success.selected {
-    border-color: #00820d;
-    background-color: #00820d;
-    color: #ffffff;
+	border-color: #00820d;
+	background-color: #00820d;
+	color: #ffffff;
 }
 
 .btn-link {

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -174,11 +174,11 @@ h3, .h3 {
 }
 
 a:not(.btn), a:link:not(.btn), a:visited:not(.btn) {
-	color: #0075bc;
+	color: #004a8b;
 }
 
 a:hover {
-	color: #0065a3;
+	color: #004a8b;
 }
 
 .bottom-right {
@@ -321,15 +321,21 @@ a.nav-link.disabled:hover, a.nav-link.disabled:active, a.nav-link.disabled:focus
 	color: #ffffff;
 }
 
+.btn-success {
+    color: #ffffff;
+    background-color: #00820d;
+    border-color: #00820d;
+}
+
 .btn-outline-success {
-	border-color: #28A745;
-	color: #28A745;
+    border-color: #00820d;
+    color: #00820d;
 }
 
 .btn-outline-success:hover, .btn-outline-success:focus, .btn-outline-success:active, .btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success.selected {
-	border-color: #28A745;
-	background-color: #28A745;
-	color: #ffffff;
+    border-color: #00820d;
+    background-color: #00820d;
+    color: #ffffff;
 }
 
 .btn-link {
@@ -501,10 +507,6 @@ h3.alert-heading {
 
 .remaining-controls {
 	margin-left: 20px;
-}
-
-.page-content-flow {
-	margin-top: 0.5rem;
 }
 
 .input-group-text {


### PR DESCRIPTION
This PR tries to address the color contrast issues identified during the accessibility review. A couple other supporting or miscellaneous edits to the user interface and associated language are included. Comments will added requesting specific feedback on proposed hex values or changes. Other changes are described in a task list below. The PR aims to resolve issue #155.

- [x] Replace CSS class called `page-content-flow` which I previously introduced with the use of Bootstrap margin utilities (e.g. `mt-3`).
- [x] Remove link, but not button, from Tab order for Add Queue button, making only one action related to the function keyboard accessible.
- [x] Change label text for the `queue.created_at` value to "Created", as it is in the current release.