### PR TITLE
Modify showConfirmation, ensure confirmation pop-up when user leaves line (#137)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -86,10 +86,10 @@ export const LoadingDisplay: React.FC<LoadingDisplayProps> = (props) => {
 }
 
 
-export const showConfirmation = (dialog: React.RefObject<Dialog>, action: () => void, title: string, actionDescription: string) => {
+export const showConfirmation = (dialog: React.RefObject<Dialog>, action: () => void, title: string, description: string) => {
     dialog.current!.show({
         title: title,
-        body: `Are you sure you want to ${actionDescription}?`,
+        body: description,
         actions: [
             Dialog.CancelAction(),
             Dialog.OKAction(action),

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -351,10 +351,11 @@ export function QueuePage(props: PageProps<QueuePageParams>) {
     }
     const [doLeaveQueue, leaveQueueLoading, leaveQueueError] = usePromise(leaveQueue);
     const confirmLeaveQueue = (queueStatus: 'open' | 'closed') => {
+        const loseMessage = 'By leaving the queue, you will lose your place in line'
         const description = 'Are you sure you want to leave the queue? ' + (
             queueStatus === 'open'
-                ? "You will lose your place in line."
-                : "The queue is currently closed. If you leave now, you will not be able to rejoin until the queue is reopened."
+                ? loseMessage + '.'
+                : `The queue is currently closed. ${loseMessage} and will not be able to rejoin until the queue is reopened.`
         );
         showConfirmation(dialogRef, () => doLeaveQueue(), 'Leave Queue?', description);
     }

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -371,7 +371,12 @@ export function QueueManagerPage(props: PageProps<QueueManagerPageParams>) {
     }
     const [doRemoveMeeting, removeMeetingLoading, removeMeetingError] = usePromise(removeMeeting);
     const confirmRemoveMeeting = (m: Meeting) => {
-        showConfirmation(dialogRef, () => doRemoveMeeting(m), "Remove Meeting?", `remove your meeting with ${m.attendees[0].first_name} ${m.attendees[0].last_name}`);
+        showConfirmation(
+            dialogRef,
+            () => doRemoveMeeting(m),
+            "Remove Meeting?",
+            `Are you sure you want to remove your meeting with ${m.attendees[0].first_name} ${m.attendees[0].last_name}?`
+        );
     }
     const addMeeting = async (uniqname: string, backend: string) => {
         const user = await confirmUserExists(uniqname);

--- a/src/assets/src/components/queueSettings.tsx
+++ b/src/assets/src/components/queueSettings.tsx
@@ -166,7 +166,7 @@ export function ManageQueueSettingsPage(props: PageProps<SettingsPageParams>) {
     }
     const [doRemoveHost, removeHostLoading, removeHostError] = usePromise(removeHost);
     const confirmRemoveHost = (h: User) => {
-        showConfirmation(dialogRef, () => doRemoveHost(h), "Remove Host?", `remove host ${h.username}`);
+        showConfirmation(dialogRef, () => doRemoveHost(h), "Remove Host?", `Are you sure you want to remove host ${h.username}?`);
     }
     const addHost = async (uniqname: string) => {
         const user = await confirmUserExists(uniqname);
@@ -182,7 +182,7 @@ export function ManageQueueSettingsPage(props: PageProps<SettingsPageParams>) {
     }
     const [doRemoveQueue, removeQueueLoading, removeQueueError] = usePromise(removeQueue);
     const confirmRemoveQueue = () => {
-        showConfirmation(dialogRef, () => doRemoveQueue(), "Delete Queue?", "permanently delete this queue");
+        showConfirmation(dialogRef, () => doRemoveQueue(), "Delete Queue?", "Are you sure you want to permanently delete this queue?");
     }
 
     // On change handlers


### PR DESCRIPTION
This PR makes changes to the `queue.tsx` component so users are shown a pop-up confirmation (with language different whether the queue status is "open" or "closed") whenever they click the "Leave the line" button. I also refactored a little to minimize duplication and tweaked `showConfirmation` (perhaps arbitrarily) so that it doesn't prescribe a prefix or introductory language for the pop-up's body message. See comments on the code for explanations. The PR aims to resolve issue #137.