### PR TITLE
Reintroduce self-focusing code to improve EditToggleField accessibility (#156)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -8,6 +8,7 @@ import Dialog from "react-bootstrap-dialog";
 import { StringSchema } from "yup";
 
 import { useStringValidation } from "../hooks/useValidation";
+import { useInitFocusRef } from "../hooks/useInitFocusRef";
 import { QueueAttendee, QueueBase, User } from "../models";
 import { ValidationResult } from "../validation";
 
@@ -212,13 +213,7 @@ interface StatelessValidatedInputFormProps extends SingleInputFormProps {
 }
 
 export const StatelessInputGroupForm: React.FC<StatelessValidatedInputFormProps> = (props) => {
-    const inputRef = createRef<FormControl<"input"> & HTMLInputElement>();
-    useEffect(() => {
-        if (props.initFocus) {
-            inputRef.current!.focus();
-        }
-    }, []);
-
+    const inputRef = useInitFocusRef<FormControl<"input"> & HTMLInputElement>(!!props.initFocus);
     const handleChange = (newValue: string) => props.onChangeValue(newValue);
 
     let buttonBlock;
@@ -271,13 +266,7 @@ export const StatelessInputGroupForm: React.FC<StatelessValidatedInputFormProps>
 }
 
 export const StatelessTextAreaForm: React.FC<StatelessValidatedInputFormProps> = (props) => {
-    const inputRef = createRef<FormControl<"textarea"> & HTMLTextAreaElement>();
-    useEffect(() => {
-        if (props.initFocus) {
-            inputRef.current!.focus();
-        }
-    }, []);
-
+    const inputRef = useInitFocusRef<FormControl<'textarea'> & HTMLTextAreaElement>(!!props.initFocus);
     const handleChange = (newValue: string) => props.onChangeValue(newValue);
 
     let buttonBlock;

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -382,11 +382,15 @@ interface EditToggleFieldProps extends SingleInputFieldProps {
 // Wrapper for input fields that can be expanded or hidden with an Edit button
 export const EditToggleField: React.FC<EditToggleFieldProps> = (props) => {
     const [editing, setEditing] = useState(props.initialState);
+    const [initFocus, setInitFocus] = useState(!props.initialState);
 
-    const toggleEditMode = () => setEditing(!editing);
+    const toggleEditMode = () => {
+        setEditing(!editing);
+        setInitFocus(true);
+    }
 
     const contents = (editing && !props.disabled)
-        ? <SingleInputField {...props} initFocus={true} onSuccess={toggleEditMode}>{props.children}</SingleInputField>
+        ? <SingleInputField {...props} initFocus={initFocus} onSuccess={toggleEditMode}>{props.children}</SingleInputField>
         : (
             <div className="input-group">
                 <span>{props.value}</span>

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { createRef, useState } from "react";
+import { createRef, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSyncAlt, faClipboard, faClipboardCheck, faPencilAlt, faTrashAlt, faHome } from '@fortawesome/free-solid-svg-icons';
-import { Alert, Badge, Breadcrumb, Button, Form, InputGroup, Modal, Table } from "react-bootstrap";
+import { Alert, Badge, Breadcrumb, Button, Form, FormControl, InputGroup, Modal, Table } from "react-bootstrap";
 import Dialog from "react-bootstrap-dialog";
 import { StringSchema } from "yup";
 
@@ -200,6 +200,7 @@ interface SingleInputFormProps {
     placeholder: string;
     disabled: boolean;
     buttonOptions?: ButtonOptions;
+    initFocus?: boolean;
 }
 
 // Stateless Field Components
@@ -211,6 +212,13 @@ interface StatelessValidatedInputFormProps extends SingleInputFormProps {
 }
 
 export const StatelessInputGroupForm: React.FC<StatelessValidatedInputFormProps> = (props) => {
+    const inputRef = createRef<FormControl<"input"> & HTMLInputElement>();
+    useEffect(() => {
+        if (props.initFocus) {
+            inputRef.current!.focus();
+        }
+    }, []);
+
     const handleChange = (newValue: string) => props.onChangeValue(newValue);
 
     let buttonBlock;
@@ -247,6 +255,7 @@ export const StatelessInputGroupForm: React.FC<StatelessValidatedInputFormProps>
                 <Form.Control
                     id={props.id}
                     as='input'
+                    ref={inputRef}
                     className='form-control-remaining'
                     value={props.value}
                     placeholder={props.placeholder}
@@ -254,7 +263,7 @@ export const StatelessInputGroupForm: React.FC<StatelessValidatedInputFormProps>
                     disabled={props.disabled}
                     isInvalid={props.validationResult?.isInvalid}
                 />
-            {buttonBlock}
+                {buttonBlock}
             </InputGroup>
             {feedback}
         </Form>
@@ -262,6 +271,13 @@ export const StatelessInputGroupForm: React.FC<StatelessValidatedInputFormProps>
 }
 
 export const StatelessTextAreaForm: React.FC<StatelessValidatedInputFormProps> = (props) => {
+    const inputRef = createRef<FormControl<"textarea"> & HTMLTextAreaElement>();
+    useEffect(() => {
+        if (props.initFocus) {
+            inputRef.current!.focus();
+        }
+    }, []);
+
     const handleChange = (newValue: string) => props.onChangeValue(newValue);
 
     let buttonBlock;
@@ -296,6 +312,7 @@ export const StatelessTextAreaForm: React.FC<StatelessValidatedInputFormProps> =
                 <Form.Control
                     id={props.id}
                     as='textarea'
+                    ref={inputRef}
                     rows={5}
                     className='form-control-remaining'
                     value={props.value}
@@ -328,6 +345,7 @@ interface SingleInputFieldProps {
     placeholder: string;
     disabled: boolean;
     buttonOptions: ButtonOptions;
+    initFocus?: boolean;
     fieldComponent: React.FC<StatelessValidatedInputFormProps>;
     fieldSchema: StringSchema;
     showRemaining?: boolean;
@@ -379,7 +397,7 @@ export const EditToggleField: React.FC<EditToggleFieldProps> = (props) => {
     const toggleEditMode = () => setEditing(!editing);
 
     const contents = (editing && !props.disabled)
-        ? <SingleInputField {...props} onSuccess={toggleEditMode}>{props.children}</SingleInputField>
+        ? <SingleInputField {...props} initFocus={true} onSuccess={toggleEditMode}>{props.children}</SingleInputField>
         : (
             <div className="input-group">
                 <span>{props.value}</span>

--- a/src/assets/src/hooks/useInitFocusRef.ts
+++ b/src/assets/src/hooks/useInitFocusRef.ts
@@ -1,8 +1,8 @@
 import { createRef, useEffect, RefObject } from "react";
 
 export function useInitFocusRef<T extends HTMLElement>(initFocus: boolean): RefObject<T> | undefined {
-    const ref = createRef<T>();
     if (!initFocus) return undefined;
+    const ref = createRef<T>();
     useEffect(() => {
         if (initFocus) ref.current!.focus();
     }, []);

--- a/src/assets/src/hooks/useInitFocusRef.ts
+++ b/src/assets/src/hooks/useInitFocusRef.ts
@@ -1,0 +1,10 @@
+import { createRef, useEffect, RefObject } from "react";
+
+export function useInitFocusRef<T extends HTMLElement>(initFocus: boolean): RefObject<T> | undefined {
+    const ref = createRef<T>();
+    if (!initFocus) return undefined;
+    useEffect(() => {
+        if (initFocus) ref.current!.focus();
+    }, []);
+    return ref;
+}


### PR DESCRIPTION
This PR adds code similar to a preexisting pattern in the project that allows `SingleInputField` components to focus their underlying input fields on initial render. This is then used by the `EditToggleField` to ensure the form input receives when the field is toggled to an `editing` state. Note: The `EditToggleField` is now only used by attendees when entering agenda values. The PR aims to resolve PR #156.