### PR TITLE
Prompt user to refresh after failed WebSocket reconnects (#168)

### DIFF
--- a/src/assets/src/hooks/useWebSocket.ts
+++ b/src/assets/src/hooks/useWebSocket.ts
@@ -8,7 +8,7 @@ interface OfficeHoursMessage<T> {
 
 export const useWebSocket = <T>(url: string, onUpdate: (content: T) => void, onDelete?: (setError: (React.Dispatch<React.SetStateAction<Error | undefined>>)) => void) => {
     const [error, setError] = useState(undefined as Error | undefined);
-    const numRetries = 3;
+    const numRetries = 10;
     useEffect(() => {
         const ws = new ReconnectingWebSocket(
             url,


### PR DESCRIPTION
This PR uses `ws.retryCount` to change the connection error messages to indicate "Unable to reconnect; please refresh the page". The PR aims to resolve issue #168.

Is this what you had in mind, @jlost? Feel free to push to or open a PR against the branch on my fork.