### PR TITLE
Use blue focus indicator for .btn-warning (#158)

### DIFF
--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -182,7 +182,7 @@ a:hover {
 }
 
 .btn-warning:focus {
-	box-shadow: 0 0 0 0.2rem rgba(12, 61, 222, 0.5);
+	box-shadow: 0 0 0 0.2rem #0c3dde7f;
 }
 
 .bottom-right {

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -181,6 +181,10 @@ a:hover {
 	color: #0065a3;
 }
 
+.btn-warning:focus {
+	box-shadow: 0 0 0 0.2rem rgba(12, 61, 222, 0.5);
+}
+
 .bottom-right {
 	position: fixed;
 	bottom: 0;


### PR DESCRIPTION
Increases contrast from orange color for accessibility.
Closes #158 