### PR TITLE
Tidy up CSS to use reds, greens, and other formatting consistently, eliminate custom CSS classes (#159)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -251,7 +251,6 @@ export const StatelessInputGroupForm: React.FC<StatelessValidatedInputFormProps>
                     id={props.id}
                     as='input'
                     ref={inputRef}
-                    className='form-control-remaining'
                     value={props.value}
                     aria-label={props.formLabel}
                     placeholder={props.placeholder}
@@ -304,7 +303,6 @@ export const StatelessTextAreaForm: React.FC<StatelessValidatedInputFormProps> =
                     as='textarea'
                     rows={5}
                     ref={inputRef}
-                    className='form-control-remaining'
                     value={props.value}
                     aria-label={props.formLabel}
                     placeholder={props.placeholder}
@@ -509,13 +507,12 @@ interface QueueTableProps {
 
 export function QueueTable (props: QueueTableProps) {
     const linkBase = props.manageLink ? '/manage/' : '/queue/'
-    const badgeClass = 'queue-table-badge'
 
     const queueItems = props.queues.map(q => (
         <tr key={q.id}>
             <td aria-label={`Queue ID Number`}>
                 <Link to={`${linkBase}${q.id}`}>
-                    <Badge className={badgeClass} variant='primary' pill={true}>{q.id}</Badge>
+                    <Badge variant='primary' pill={true}>{q.id}</Badge>
                 </Link>
             </td>
             <td aria-label={`Name for Queue ID ${q.id}`}>
@@ -523,7 +520,7 @@ export function QueueTable (props: QueueTableProps) {
             </td>
             <td aria-label={`Status for Queue ID ${q.id}`}>
                 <Link to={`${linkBase}${q.id}`}>
-                    <Badge className={badgeClass} variant={q.status === 'open' ? 'success' : 'danger'} pill={true}>
+                    <Badge variant={q.status === 'open' ? 'success' : 'danger'} pill={true}>
                         {q.status}
                     </Badge>
                 </Link>

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -134,7 +134,6 @@ function AddAttendeeForm(props: AddAttendeeFormProps) {
                 <Form.Control
                     id='add_attendee'
                     as='input'
-                    className='form-control-remaining'
                     value={attendee}
                     placeholder='Uniqname...'
                     onChange={handleAttendeeChange}

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -202,6 +202,8 @@ p a:not(.btn) {
 	padding: 1.25rem;
 }
 
+/* !important is needed to override another !important used in the text-emphasis Bootstrap mixin.
+   We should re-evaluate this in the future and potentially customize the danger value using Sass. */
 .text-danger {
 	color: var(--custom-red) !important;
 }

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -181,11 +181,11 @@ a:hover {
 	color: #0060ba;
 }
 
-.alert a {
+.alert a:not(.btn) {
 	text-decoration: underline;
 }
 
-p a {
+p a:not(.btn) {
 	text-decoration: underline;
 }
 
@@ -200,9 +200,13 @@ p a {
 	padding: 1.25rem;
 }
 
+.text-danger {
+	color: #CC0000 !important;
+}
+
 .btn-danger {
 	background-color: #CC0000;
-	border-color: #cc0000;
+	border-color: #CC0000;
 }
 
 .btn-danger:hover.btn-danger:not(:disabled), .btn-danger:focus.btn-danger:not(:disabled) {
@@ -492,8 +496,13 @@ h3.alert-heading {
 	border: 1px solid #cecbc9;
 }
 
-.form-control-remaining.is-invalid {
+.form-control.is-invalid {
+	border-color: #CC0000;
 	background-image: none;
+}
+
+.form-control.is-invalid:focus {
+	border-color: #CC0000;
 }
 
 /* Overrides styling of feedback so it can be used consistently, anywhere */
@@ -667,6 +676,14 @@ div[role=main] {
 	padding-left: 5px
 }
 
-.queue-table-badge {
+.badge {
 	font-size: 90%;
+}
+
+.badge-danger {
+	background-color: #CC0000;
+}
+
+.badge-success {
+	background-color: #00820D;
 }

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -2,6 +2,8 @@
 	--dark-blue: #00274C;
 	--med-blue: #40658F;
 	--light-blue: #6189b7;
+	--custom-red: #CC0000;
+	--custom-green: #00820D;
 }
 
 body {
@@ -201,12 +203,12 @@ p a:not(.btn) {
 }
 
 .text-danger {
-	color: #CC0000 !important;
+	color: var(--custom-red) !important;
 }
 
 .btn-danger {
-	background-color: #CC0000;
-	border-color: #CC0000;
+	background-color: var(--custom-red);
+	border-color: var(--custom-red);
 }
 
 .btn-danger:hover.btn-danger:not(:disabled), .btn-danger:focus.btn-danger:not(:disabled) {
@@ -335,18 +337,18 @@ a.nav-link.disabled:hover, a.nav-link.disabled:active, a.nav-link.disabled:focus
 
 .btn-success {
 	color: #ffffff;
-	background-color: #00820d;
-	border-color: #00820d;
+	background-color: var(--custom-green);
+	border-color: var(--custom-green);
 }
 
 .btn-outline-success {
-	border-color: #00820d;
-	color: #00820d;
+	border-color: var(--custom-green);
+	color: var(--custom-green);
 }
 
 .btn-outline-success:hover, .btn-outline-success:focus, .btn-outline-success:active, .btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success.selected {
-	border-color: #00820d;
-	background-color: #00820d;
+	border-color: var(--custom-green);
+	background-color: var(--custom-green);
 	color: #ffffff;
 }
 
@@ -497,12 +499,12 @@ h3.alert-heading {
 }
 
 .form-control.is-invalid {
-	border-color: #CC0000;
+	border-color: var(--custom-red);
 	background-image: none;
 }
 
 .form-control.is-invalid:focus {
-	border-color: #CC0000;
+	border-color: var(--custom-red);
 }
 
 /* Overrides styling of feedback so it can be used consistently, anywhere */
@@ -624,7 +626,7 @@ pre {
 }
 
 .card-not-selected {
-	border-color: #cc0000 !important;
+	border-color: var(--custom-red) !important;
 	border-width: 3px !important;
 }
 
@@ -664,7 +666,7 @@ div[role=main] {
 }
 
 .required {
-	color: #cc0000;
+	color: var(--custom-red);
 }
 
 .meeting-type-text-container {
@@ -681,9 +683,9 @@ div[role=main] {
 }
 
 .badge-danger {
-	background-color: #CC0000;
+	background-color: var(--custom-red);
 }
 
 .badge-success {
-	background-color: #00820D;
+	background-color: var(--custom-green);
 }


### PR DESCRIPTION
This PR makes several changes to `main.css` in order to make the use of `danger` and `success` colors and badge formatting consistent across the application. It also transforms existing custom CSS classes into classes that will override the Bootstrap defaults (`form-control.is-invalid` and `badge`), which allowed for the removal of `className` usages in `common.tsx`. More details will be provided in a task list. The PR aims to resolve issue #159.

- [x] Use `#CC0000` for all solid red UI features and standalone text (includes buttons, badges, validation formatting and feedback, button text; it does not include alert background or text).
- [x] Use `#00820D` for all solid green UI features (includes buttons and badges; it does not include alert background). Note: `text-success` was not specified, as it is not in use anywhere (that I'm aware of).
- [x] Make all badge text use `font-size: 90%`,  which affects the badges in the queue tables and the "In Person" badge in the meetings list on the Manage page.
- [x] Fix underline rules introduced in PR  #191 so they don't apply to buttons in alerts.