### PR TITLE
Add space between sentences for Manage Hosts instructions

### DIFF
--- a/src/assets/src/components/queueEditors.tsx
+++ b/src/assets/src/components/queueEditors.tsx
@@ -134,8 +134,7 @@ export function ManageHostsEditor(props: ManageHostsEditorProps) {
             </SingleInputField>
             <h3>Current Hosts</h3>
             <p>
-                To remove a host, select the trash icon to the right of the user's name.
-                <strong>You cannot remove yourself as a host.</strong>
+                To remove a host, select the trash icon to the right of the user's name. <strong>You cannot remove yourself as a host.</strong>
             </p>
             <ListGroup>{hostsSoFar}</ListGroup>
         </div>


### PR DESCRIPTION
The PR adds a space between the two sentences in the instructional text for "Current Hosts" section of the `ManageHostsEditor`.