### PR TITLE
Modify PhoneInput to limit to US/Canada, simplify user input, improve styling (#212)

### DIFF
--- a/src/assets/src/components/preferences.tsx
+++ b/src/assets/src/components/preferences.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useState, useEffect } from "react";
 import { Alert, Button, Form } from "react-bootstrap";
 import PhoneInput from "react-phone-input-2";
-import 'react-phone-input-2/lib/style.css'
+import 'react-phone-input-2/lib/bootstrap.css'
 
 import * as api from "../services/api";
 import { MyUser } from "../models";
@@ -36,6 +36,8 @@ function PreferencesEditor(props: PreferencesEditorProps) {
     const phoneInput = (
         <PhoneInput
             country={'us'}
+            onlyCountries={['us', 'ca']}
+            countryCodeEditable={false}
             value={props.user.phone_number}
             onChange={(value: any, data: any) => {
                 setPhoneField(value);

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -41,7 +41,10 @@ export const confirmUserExists = async (uniqname: string) => {
 export const validatePhoneNumber = (phone: string, countryDialCode: string): Error[] => {
     return [
         (countryDialCode === '1' && phone.length !== 11)
-            && new Error("The phone number entered was invalid; USA phone numbers must have 11 digits."),
+            && new Error(
+                'Please enter a valid US/Canada phone number with area code ' +
+                '(11 digits including +1 country code) that can receive SMS messages.'
+            ),
     ].filter(e => e) as Error[];
 }
 


### PR DESCRIPTION
This PR makes a few changes to `preferences.tsx` and `validation.ts` in order to limit phone numbers entered to those from the US and Canada, as well as simplify the input. More details are provided in a task list below. The PR aims to resolve issue #212.

- [x] Specified `onlyCountries={['us', 'ca']}` in `PhoneInput` to limit the possible country codes to just `+1`.
- [x] Specified `countryCodeEditable={false}` in `PhoneInput` so users must use the dropdown menu to change the country code (eleviating some of the awkwardness of entering phone numbers, noted in #212) .
- [x] Combined the existing invalid phone number message in `validatePhoneNumber` with the new text provided by @mfldavidson .
- [x] Changed the CSS style from the `style` variant to `bootstrap` because it has better focus treatment for the country code dropdown menu, and (at least theoretically) should be more consistent aesthetically with the rest of the application.