### PR TITLE
Add "Back to Queue" button to Queue Settings page (#208)

### DIFF
--- a/src/assets/src/components/queueSettings.tsx
+++ b/src/assets/src/components/queueSettings.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
 import { createRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
 import { Button, Col, Nav, Row, Tab } from "react-bootstrap";
 import Dialog from "react-bootstrap-dialog";
 
@@ -35,7 +38,12 @@ function QueueSettingsEditor(props: QueueSettingsProps) {
         <Tab.Container id='add-queue-editor' defaultActiveKey='general'>
             <Row>
                 <Col md={3} sm={3}>
-                    <Nav variant='pills' className='flex-column mt-5'>
+                    <div className='mt-4'>
+                        <Link to={`/manage/${props.queue.id}/`}>
+                            <FontAwesomeIcon icon={faChevronLeft} /> Back to Queue
+                        </Link>
+                    </div>
+                    <Nav variant='pills' className='flex-column mt-4'>
                         <Nav.Item>
                             <Nav.Link eventKey='general' role='tab-custom' tabIndex={0} aria-label='General Tab'>
                                 General


### PR DESCRIPTION
This PR adds a button back to the "Manage: {Queue Name}" page from the Queue Settings page. While navigation links were already present in the Breadcrumbs, this makes the back action more apparent. The PR aims to resolve issue #208.

Screenshot
<img width="600" alt="Screen Shot 2020-11-05 at 10 07 09 AM" src="https://user-images.githubusercontent.com/35741256/98258283-ad47b500-1f4e-11eb-9037-6a0cdcc89c1c.png">
