### PR TITLE
Add Manage link to Add Queue breadcrumbs (#95)

### DIFF
--- a/src/assets/src/components/addQueue.tsx
+++ b/src/assets/src/components/addQueue.tsx
@@ -212,7 +212,10 @@ export function AddQueuePage(props: PageProps) {
     return (
         <div>
             <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl} />
-            <Breadcrumbs currentPageTitle='Add Queue' />
+            <Breadcrumbs
+                intermediatePages={[{ title: 'Manage', href: '/manage/' }]}
+                currentPageTitle='Add Queue'
+            />
             <LoadingDisplay loading={isChanging} />
             <ErrorDisplay formErrors={globalErrors} />
             <AddQueueEditor


### PR DESCRIPTION
This PR adds the "Manage" link to the breadcrumbs on the Add Queue page, which I had neglected to add previously. This keeps the breadcrumb pattern consistent with the other management pages. This contributes to the already finished work of issue #95.