### PR TITLE
Add Profile fields to User page on admin site (#215)

### DIFF
--- a/src/officehours_api/admin.py
+++ b/src/officehours_api/admin.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.models import User
 from safedelete.admin import SafeDeleteAdmin, highlight_deleted
-from officehours_api.models import Queue, Meeting, Attendee
+
+from officehours_api.models import Queue, Meeting, Attendee, Profile
 
 
 @admin.register(Queue)
@@ -21,3 +24,17 @@ class MeetingAdmin(admin.ModelAdmin):
     list_filter = ('queue',)
     search_fields = ['id', 'queue__name']
     inlines = (AttendeeInline,)
+
+
+class ProfileInline(admin.StackedInline):
+    model = Profile
+    can_delete = False
+    verbose_name_plural = 'profile'
+
+
+class UserAdmin(BaseUserAdmin):
+    inlines = (ProfileInline,)
+
+
+admin.site.unregister(User)
+admin.site.register(User, UserAdmin)


### PR DESCRIPTION
This PR follows the [pattern detailed in the Django docs](https://docs.djangoproject.com/en/3.1/topics/auth/customizing/#extending-the-existing-user-model) to extend the existing `UserAdmin` to include the fields from the `Profile` model ("Phone number", "Notify me attendee", and "Notify me host"). The PR aims to resolve issue #215.



