### PR TITLE
Fix check for changed values in Queue Settings to enable blank description (#221)

### DIFF
--- a/src/assets/src/components/queueSettings.tsx
+++ b/src/assets/src/components/queueSettings.tsx
@@ -222,7 +222,7 @@ export function ManageQueueSettingsPage(props: PageProps<SettingsPageParams>) {
             const descriptForUpdate = description.trim() !== queue?.description ? description : undefined;
             const allowedForUpdate = checkIfSetsAreDifferent(new Set(queue!.allowed_backends), allowedMeetingTypes)
                 ? allowedMeetingTypes : undefined;
-            if (nameForUpdate || descriptForUpdate || allowedForUpdate) {
+            if (nameForUpdate !== undefined || descriptForUpdate !== undefined || allowedForUpdate) {
                 doUpdateQueue(nameForUpdate, descriptForUpdate, allowedForUpdate);
                 setShowSuccessMessage(true);
             }


### PR DESCRIPTION
This PR fixes the logic in the "Save Changes" on click handler in `QueueSettingsEditor`. Previously, I was simply checking whether the boolean value of `descriptForUpdate` was `true`, which missed the possibility of an empty string (which is falsy). I updated the logic in the condition to check specifically whether `descriptForUpdate` is not `undefined`, which is the fallback if the values are found to be the same. I also updated the `nameForUpdate` check to also use `!== undefined`; while the name field can't be an empty string (because of validation), it seemed safer to futureproof this, since the same problem could occur if the validation logic changes. The PR aims to resolve issue #221.