### PR TITLE
Sort queues by QueueBase.status and QueueBase.id descending (#205)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -10,6 +10,7 @@ import { StringSchema } from "yup";
 import { useStringValidation } from "../hooks/useValidation";
 import { useInitFocusRef } from "../hooks/useInitFocusRef";
 import { QueueAttendee, QueueBase, User } from "../models";
+import { sortQueues } from "../sort";
 import { ValidationResult } from "../validation";
 
 type BootstrapButtonTypes = "info" | "warning" | "success" | "primary" | "alternate" | "danger";
@@ -503,14 +504,15 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
 }
 
 interface QueueTableProps {
-    queues: QueueBase[];
+    queues: readonly QueueBase[];
     manageLink?: boolean | undefined;
 }
 
 export function QueueTable (props: QueueTableProps) {
     const linkBase = props.manageLink ? '/manage/' : '/queue/'
 
-    const queueItems = props.queues.map(q => (
+    const sortedQueues = sortQueues(props.queues.slice());
+    const queueItems = sortedQueues.map(q => (
         <tr key={q.id}>
             <td aria-label={`Queue ID Number`}>
                 <Link to={`${linkBase}${q.id}`}>

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -503,7 +503,7 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
 }
 
 interface QueueTableProps {
-    queues: ReadonlyArray<QueueBase>;
+    queues: QueueBase[];
     manageLink?: boolean | undefined;
 }
 

--- a/src/assets/src/components/manage.tsx
+++ b/src/assets/src/components/manage.tsx
@@ -8,7 +8,6 @@ import { PageProps } from "./page";
 import { QueueBase } from "../models";
 import { useUserWebSocket } from "../services/sockets";
 import { redirectToLogin } from "../utils";
-import { sortQueues } from "../sort";
 
 
 interface ManageQueueTableProps {
@@ -18,7 +17,7 @@ interface ManageQueueTableProps {
 
 function ManageQueueTable(props: ManageQueueTableProps) {
     const queueResults = props.queues.length
-        ? <QueueTable queues={sortQueues(props.queues.slice())} manageLink={true} />
+        ? <QueueTable queues={props.queues} manageLink={true} />
         : <p>No queues to display. Create a queue by clicking the "Add Queue" button below.</p>;
     return (
         <div>

--- a/src/assets/src/components/manage.tsx
+++ b/src/assets/src/components/manage.tsx
@@ -8,6 +8,7 @@ import { PageProps } from "./page";
 import { QueueBase } from "../models";
 import { useUserWebSocket } from "../services/sockets";
 import { redirectToLogin } from "../utils";
+import { sortQueues } from "../sort";
 
 
 interface ManageQueueTableProps {
@@ -17,8 +18,8 @@ interface ManageQueueTableProps {
 
 function ManageQueueTable(props: ManageQueueTableProps) {
     const queueResults = props.queues.length
-        ? <QueueTable queues={props.queues} manageLink={true}/>
-        : <p>No queues to display. Create a queue by clicking the "Add Queue" button below.</p>
+        ? <QueueTable queues={sortQueues(props.queues.slice())} manageLink={true} />
+        : <p>No queues to display. Create a queue by clicking the "Add Queue" button below.</p>;
     return (
         <div>
             {queueResults}

--- a/src/assets/src/components/search.tsx
+++ b/src/assets/src/components/search.tsx
@@ -6,7 +6,6 @@ import { usePromise } from "../hooks/usePromise";
 import { searchQueue as apiSearchQueue } from "../services/api";
 import { LoadingDisplay, ErrorDisplay, FormError, Breadcrumbs, QueueTable } from "./common";
 import { redirectToLogin } from "../utils";
-import { sortQueues } from "../sort";
 import { PageProps } from "./page";
 
 
@@ -40,7 +39,7 @@ export function SearchPage(props: PageProps<SearchPageParams>) {
                     No results were found for "{term}".
                 </p>
             )
-            : <QueueTable queues={sortQueues(searchResults.slice())} />
+            : <QueueTable queues={searchResults} />
     const redirectAlert = props.location.search.includes("redirected=true") && !/^\d+$/.exec(term)
         && (
             <p className="alert alert-warning">

--- a/src/assets/src/components/search.tsx
+++ b/src/assets/src/components/search.tsx
@@ -6,6 +6,7 @@ import { usePromise } from "../hooks/usePromise";
 import { searchQueue as apiSearchQueue } from "../services/api";
 import { LoadingDisplay, ErrorDisplay, FormError, Breadcrumbs, QueueTable } from "./common";
 import { redirectToLogin } from "../utils";
+import { sortQueues } from "../sort";
 import { PageProps } from "./page";
 
 
@@ -39,7 +40,7 @@ export function SearchPage(props: PageProps<SearchPageParams>) {
                     No results were found for "{term}".
                 </p>
             )
-            : <QueueTable queues={searchResults} />
+            : <QueueTable queues={sortQueues(searchResults.slice())} />
     const redirectAlert = props.location.search.includes("redirected=true") && !/^\d+$/.exec(term)
         && (
             <p className="alert alert-warning">

--- a/src/assets/src/sort.ts
+++ b/src/assets/src/sort.ts
@@ -1,5 +1,6 @@
 import { QueueBase } from "./models";
 
+
 type CompareQueueFunc = (a: QueueBase, b: QueueBase) => number;
 
 const compareQueueStatus: CompareQueueFunc = (a, b) => {
@@ -7,9 +8,8 @@ const compareQueueStatus: CompareQueueFunc = (a, b) => {
         return -1;
     } else if (a.status === 'closed' && b.status === 'open') {
         return 1;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 const compareQueueIDDesc: CompareQueueFunc = (a, b) => {

--- a/src/assets/src/sort.ts
+++ b/src/assets/src/sort.ts
@@ -21,5 +21,5 @@ const compareQueueIDDesc: CompareQueueFunc = (a, b) => {
 }
 
 export const sortQueues = (queues: QueueBase[]): QueueBase[] => {
-    return queues.sort(compareQueueIDDesc).sort(compareQueueStatus)
+    return queues.sort(compareQueueIDDesc).sort(compareQueueStatus);
 }

--- a/src/assets/src/sort.ts
+++ b/src/assets/src/sort.ts
@@ -1,0 +1,25 @@
+import { QueueBase } from "./models";
+
+type CompareQueueFunc = (a: QueueBase, b: QueueBase) => number;
+
+const compareQueueStatus: CompareQueueFunc = (a, b) => {
+    if (a.status === 'open' && b.status === 'closed') {
+        return -1;
+    } else if (a.status === 'closed' && b.status === 'open') {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+const compareQueueIDDesc: CompareQueueFunc = (a, b) => {
+    if (a.id > b.id) {
+        return -1;
+    } else {
+        return 1;
+    }
+}
+
+export const sortQueues = (queues: QueueBase[]): QueueBase[] => {
+    return queues.sort(compareQueueIDDesc).sort(compareQueueStatus)
+}


### PR DESCRIPTION
This PR introduces a basic, static sorting of queues in the tables for search results (`search/x`) and the Manage Queues page (`manage/`). The sorting algorithm sorts queues by their status ("open" before "closed") and by their ID, descending from highest to lowest so the most recently created queues are at the top. The PR aims to resolve issue #205.