### PR TITLE
Refactor queueManager to introduce in-progress meeting concept (#228, #230)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -532,7 +532,7 @@ export function QueueTable (props: QueueTableProps) {
         </tr>
     ));
     return (
-        <Table bordered hover aria-label='Queue Table with Links'>
+        <Table bordered hover aria-label='Queue Table with Links' className='queue-table'>
             <thead>
                 <tr>
                     <th aria-label='Queue ID Number'>Queue ID</th>

--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -1,0 +1,263 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+import { Badge, Button, Col, Row, Table } from "react-bootstrap";
+
+import { UserDisplay, RemoveButton } from "./common";
+import { getBackendByName } from "./meetingType";
+import { Meeting, MeetingBackend, QueueHost, User } from "../models";
+
+
+interface MeetingEditorComponentProps {
+    meeting: Meeting;
+    disabled: boolean;
+}
+
+interface MeetingDetailsProps extends MeetingEditorComponentProps {
+    readableMeetingType: string;
+    onShowMeetingInfo: (m: Meeting) => void;
+}
+
+const MeetingDetails = (props: MeetingDetailsProps) => {
+    return (
+        <Row>
+            <Col md={4} className='mb-1'>
+                <Badge variant='secondary' aria-label='Meeting Type'>{props.readableMeetingType}</Badge>
+            </Col>
+            <Col md={8}>
+                <Button
+                    variant='link'
+                    size='sm'
+                    onClick={() => props.onShowMeetingInfo(props.meeting)}
+                    disabled={props.disabled}
+                >
+                    Join Info
+                </Button>
+            </Col>
+        </Row>
+    );
+}
+
+interface AssigneeSelectorProps extends MeetingEditorComponentProps {
+    user: User;
+    potentialAssignees: User[];
+    onChangeAssignee: (a: User | undefined) => void;
+}
+
+const AssigneeSelector = (props: AssigneeSelectorProps) => {
+    const assigneeOptions = [<option key={0} value="">Assign to Host...</option>]
+        .concat(
+            props.potentialAssignees
+                .sort((a, b) => a.id === props.user.id ? -1 : b.id === props.user.id ? 1 : 0)
+                .map(a => <option key={a.id} value={a.id}>{a.first_name} {a.last_name} ({a.username})</option>)
+        );
+    const onChangeAssignee = (e: React.ChangeEvent<HTMLSelectElement>) =>
+        e.target.value === ""
+            ? props.onChangeAssignee(undefined)
+            : props.onChangeAssignee(props.potentialAssignees.find(a => a.id === +e.target.value));
+
+    return (
+        <div className='form-group'>
+            <select className="form-control assign"
+                value={props.meeting.assignee?.id ?? ""}
+                onChange={onChangeAssignee}
+                disabled={props.disabled}
+            >
+                {assigneeOptions}
+            </select>
+        </div>
+    )
+}
+
+
+interface MeetingEditorProps extends MeetingDetailsProps {
+    user: User;
+    readableMeetingType: string;
+    onRemoveMeeting: (m: Meeting) => void;
+}
+
+interface UnstartedMeetingEditorProps extends MeetingEditorProps, AssigneeSelectorProps {
+    onStartMeeting: (m: Meeting) => void;
+}
+
+function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
+    const attendee = props.meeting.attendees[0];
+    const attendeeString = `${attendee.first_name} ${attendee.last_name}`;
+
+    const readyButton = props.meeting.assignee
+        && (
+            <Button
+                variant='success'
+                size='sm'
+                onClick={() => props.onStartMeeting(props.meeting)}
+                aria-label={`${props.meeting.backend_type === 'inperson' ? 'Ready for Attendee' : 'Create Meeting with'} ${attendeeString}`}
+                disabled={props.disabled}
+            >
+                {props.meeting.backend_type === 'inperson' ? 'Ready for Attendee' : 'Create Meeting'}
+            </Button>
+        );
+    const progressWorkflow = readyButton || <span>Please Assign Host</span>;
+
+    return (
+        <>
+        <td><UserDisplay user={attendee}/></td>
+        <td><AssigneeSelector {...props} /></td>
+        <td><MeetingDetails {...props} /></td>
+        <td>
+            <Row>
+                {progressWorkflow && <Col lg={7} className='mb-1'>{progressWorkflow}</Col>}
+                <Col lg={4}>
+                    <RemoveButton
+                        onRemove={() => props.onRemoveMeeting(props.meeting)}
+                        size="sm"
+                        screenReaderLabel={`Remove Meeting with ${attendeeString}`}
+                        disabled={props.disabled}
+                    />
+                </Col>
+            </Row>
+        </td>
+        </>
+    );
+}
+
+function StartedMeetingEditor (props: MeetingEditorProps) {
+    const attendee = props.meeting.attendees[0];
+    const attendeeString = `${attendee.first_name} ${attendee.last_name}`;
+    const joinUrl = props.meeting.backend_metadata?.meeting_url;
+    const role = props.user.id === props.meeting.assignee!.id ? 'Host' : 'Guest';
+    const joinLink = joinUrl
+        && (
+            <Button
+                variant='primary'
+                size='sm'
+                as='a'
+                href={joinUrl}
+                target="_blank"
+                aria-label={`Join Meeting as ${role} with ${attendeeString}`}
+                disabled={props.disabled}
+            >
+                Join Meeting as {role}
+            </Button>
+        );
+
+    return (
+        <>
+        <td><UserDisplay user={attendee}/></td>
+        <td><UserDisplay user={props.meeting.assignee!} /></td>
+        <td><MeetingDetails {...props} /></td>
+        <td>
+            <Row>
+                {joinLink && <Col lg={6} className='mb-1'>{joinLink}</Col>}
+                <Col lg={6}>
+                    <Button
+                        variant='danger'
+                        size='sm'
+                        onClick={() => props.onRemoveMeeting(props.meeting)}
+                        aria-label={`End Meeting with ${attendeeString}`}
+                        disabled={props.disabled}
+                    >
+                        End Meeting
+                    </Button>
+                </Col>
+            </Row>
+        </td>
+        </>
+    );
+}
+
+
+interface MeetingTableProps {
+    user: User;
+    meetings: Meeting[];
+    backends: MeetingBackend[];
+    onRemoveMeeting: (m: Meeting) => void;
+    onShowMeetingInfo: (m: Meeting) => void;
+    disabled: boolean;
+}
+
+interface MeetingsInQueueTableProps extends MeetingTableProps {
+    queue: QueueHost;
+    onChangeAssignee: (a: User | undefined, m: Meeting) => void;
+    onStartMeeting: (m: Meeting) => void;
+}
+
+export function MeetingsInQueueTable (props: MeetingsInQueueTableProps) {
+    const unstartedMeetingRows = props.meetings
+        .sort((a, b) => a.id - b.id)
+        .map(
+            (m, i) => (
+                <tr key={m.id}>
+                    <th scope="row" className="d-none d-sm-table-cell">{i+1}</th>
+                    <UnstartedMeetingEditor
+                        {...props}
+                        meeting={m}
+                        readableMeetingType={getBackendByName(m.backend_type, props.backends).friendly_name}
+                        potentialAssignees={props.queue.hosts}
+                        onChangeAssignee={(a: User | undefined) => props.onChangeAssignee(a, m)}
+                    />
+                </tr>
+            )
+        );
+
+    const unstartedMeetingsTable = props.meetings.length
+        ? (
+            <Table bordered responsive>
+                <thead>
+                    <tr>
+                        <th scope="col" className="d-none d-sm-table-cell">Queue #</th>
+                        <th scope="col">Attendee</th>
+                        <th scope="col">Host</th>
+                        <th scope="col">Details</th>
+                        <th scope="col">Meeting Actions</th>
+                    </tr>
+                </thead>
+                <tbody>{unstartedMeetingRows}</tbody>
+            </Table>
+        )
+        : (
+            <>
+            <hr/>
+            <p>There are currently no meetings in queue.</p>
+            <p>
+                <strong>Did you know?</strong> You can get notified by SMS (text) message when someone joins your empty queue
+                by adding your cell phone number and enabling host notifications in your <Link to="/preferences">User Preferences</Link>. 
+            </p>
+            </>
+        );
+    return unstartedMeetingsTable;
+}
+
+export function MeetingsInProgressTable (props: MeetingTableProps) {
+    const startedMeetingRows = props.meetings
+        .sort((a, b) => a.id - b.id)
+        .map((m) => (
+            <tr key={m.id}>
+                <StartedMeetingEditor
+                    {...props}
+                    meeting={m}
+                    readableMeetingType={getBackendByName(m.backend_type, props.backends).friendly_name}
+                />
+            </tr>
+        ));
+
+    const startedMeetingsTable = props.meetings.length
+        ? (
+            <Table bordered responsive>
+                <thead>
+                    <tr>
+                        <th scope="col">Attendee</th>
+                        <th scope="col">Host</th>
+                        <th scope="col">Details</th>
+                        <th scope="col">Meeting Actions</th>
+                    </tr>
+                </thead>
+                <tbody>{startedMeetingRows}</tbody>
+            </Table>
+        )
+        : (
+            <>
+            <hr/>
+            <p>There are currently no meetings in progress. Please create a meeting below to see it here.</p>
+            </>
+        );
+    return startedMeetingsTable;
+}

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -6,7 +6,7 @@ import { faCog } from "@fortawesome/free-solid-svg-icons";
 import { Alert, Badge, Button, Col, Form, InputGroup, Modal, Row } from "react-bootstrap";
 import Dialog from "react-bootstrap-dialog";
 
-import { 
+import {
     UserDisplay, ErrorDisplay, FormError, checkForbiddenError, LoadingDisplay, DateDisplay,
     CopyField, showConfirmation, LoginDialog, Breadcrumbs, DateTimeDisplay, BlueJeansDialInMessage,
     userLoggedOnWarning
@@ -16,7 +16,9 @@ import { BackendSelector as MeetingBackendSelector, getBackendByName } from "./m
 import { PageProps } from "./page";
 import { usePromise } from "../hooks/usePromise";
 import { useStringValidation } from "../hooks/useValidation";
-import { User, QueueHost, Meeting, MeetingBackend, BluejeansMetadata, isQueueHost, QueueAttendee, ZoomMetadata } from "../models";
+import {
+    BluejeansMetadata, isQueueHost, Meeting, MeetingBackend, MeetingStatus, QueueAttendee, QueueHost, User, ZoomMetadata
+} from "../models";
 import * as api from "../services/api";
 import { useQueueWebSocket } from "../services/sockets";
 import { recordQueueManagementEvent, redirectToLogin } from "../utils";
@@ -114,7 +116,7 @@ function QueueManager(props: QueueManagerProps) {
     let startedMeetings = [];
     let unstartedMeetings = [];
     for (const meeting of props.queue.meeting_set) {
-        if (meeting.status === 2) {
+        if (meeting.status ===  MeetingStatus.STARTED) {
             startedMeetings.push(meeting);
         } else {
             unstartedMeetings.push(meeting);

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -3,7 +3,7 @@ import { useState, createRef, ChangeEvent } from "react";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCog } from "@fortawesome/free-solid-svg-icons";
-import { Alert, Badge, Button, Col, Form, InputGroup, Modal, Row } from "react-bootstrap";
+import { Alert, Button, Col, Form, InputGroup, Modal, Row } from "react-bootstrap";
 import Dialog from "react-bootstrap-dialog";
 
 import {

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -33,6 +33,12 @@ export interface BluejeansMetadata {
 
 export interface ZoomMetadata extends BluejeansMetadata {}
 
+export enum MeetingStatus {
+    UNASSIGNED = 0,
+    ASSIGNED = 1,
+    STARTED = 2
+}
+
 export interface Meeting {
     id: number;
     line_place: number;
@@ -42,7 +48,7 @@ export interface Meeting {
     backend_type: EnabledBackendName;
     backend_metadata?: BluejeansMetadata|ZoomMetadata;
     created_at: string;
-    status: 0 | 1 | 2;  // 0 is UNASSIGNED, 1 is ASSIGNED, 2 is STARTED
+    status: MeetingStatus
 }
 
 

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -48,7 +48,7 @@ export interface Meeting {
     backend_type: EnabledBackendName;
     backend_metadata?: BluejeansMetadata|ZoomMetadata;
     created_at: string;
-    status: MeetingStatus
+    status: MeetingStatus;
 }
 
 

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -42,6 +42,7 @@ export interface Meeting {
     backend_type: EnabledBackendName;
     backend_metadata?: BluejeansMetadata|ZoomMetadata;
     created_at: string;
+    status: 0 | 1 | 2;  // 0 is UNASSIGNED, 1 is ASSIGNED, 2 is STARTED
 }
 
 

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -30,11 +30,17 @@ class NestedMeetingSerializer(serializers.ModelSerializer):
     attendees = NestedUserSerializer(many=True, read_only=True)
     assignee = NestedUserSerializer(read_only=True)
     backend_metadata = serializers.JSONField(read_only=True)
+    status = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Meeting
-        fields = ['id', 'attendees', 'agenda', 'assignee', 'backend_type', 'backend_metadata', 'created_at']
+        fields = [
+            'id', 'attendees', 'agenda', 'assignee', 'backend_type', 'backend_metadata', 'created_at',
+            'status'
+        ]
 
+    def get_status(self, obj):
+        return obj.status.value
 
 class NestedMyMeetingSerializer(serializers.ModelSerializer):
     backend_metadata = serializers.JSONField(read_only=True)

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -600,7 +600,7 @@ h3.alert-heading {
 	border-top: 0;
 }
 
-.table td a {
+.queue-table td a {
 	display: block;
 }
 


### PR DESCRIPTION
This PR refactors `queueManager.tsx` (moving code related to meeting editing and meeting tables into a new module, `meetingTables.tsx`) in order to allow for a separate in-progress meetings section on the Manage page. Some of the code (particularly related to the meeting type dial-in info) is preliminary. Work on related attendee-facing changes will be tackled next. The PR aims to resolve issues #228 and #230.