### PR TITLE
Modify Meeting.line_place to improve accuracy for waiting users (#244)

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -203,10 +203,10 @@ const VideoMeetingInfo: React.FC<VideoMeetingInfoProps> = (props) => {
 function QueueAttendingJoined(props: QueueAttendingProps) {
     const meeting = props.queue.my_meeting!;
     const meetingBackend = getBackendByName(meeting.backend_type, props.backends);
-    const numberInLine = meeting.line_place ? meeting.line_place + 1 : null;
+    const numberInLine = meeting.line_place !== null ? meeting.line_place + 1 : null;
     const inProgress = meeting.status === MeetingStatus.STARTED;
 
-    const turnAlert = (numberInLine !== null && meeting.status === MeetingStatus.STARTED)
+    const turnAlert = (inProgress && numberInLine === null)
         ? <MeetingReadyAlert meetingType={meetingBackend.name} />
         : <WaitingTurnAlert meetingType={meetingBackend.name} placeInLine={numberInLine!}/>;
 

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -203,12 +203,12 @@ const VideoMeetingInfo: React.FC<VideoMeetingInfoProps> = (props) => {
 function QueueAttendingJoined(props: QueueAttendingProps) {
     const meeting = props.queue.my_meeting!;
     const meetingBackend = getBackendByName(meeting.backend_type, props.backends);
-    const numberInLine = meeting.line_place + 1;
+    const numberInLine = meeting.line_place ? meeting.line_place + 1 : null;
     const inProgress = meeting.status === MeetingStatus.STARTED;
 
-    const turnAlert = (meeting.status === 2)
+    const turnAlert = (numberInLine !== null && meeting.status === MeetingStatus.STARTED)
         ? <MeetingReadyAlert meetingType={meetingBackend.name} />
-        : <WaitingTurnAlert meetingType={meetingBackend.name} placeInLine={meeting.line_place}/>;
+        : <WaitingTurnAlert meetingType={meetingBackend.name} placeInLine={numberInLine!}/>;
 
     const leave = (
         <Button
@@ -236,7 +236,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         ? <small className="ml-2">(A Host has been assigned to this meeting. Meeting Type can no longer be changed.)</small>
         : <button disabled={props.disabled} onClick={props.onShowDialog} type="button" className="btn btn-link">Change</button>;
 
-    const notificationBlurb = numberInLine > 1
+    const notificationBlurb = (numberInLine && numberInLine > 1)
         && (
             <Card.Text>
                 <Alert variant="info">

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -236,7 +236,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         ? <small className="ml-2">(A Host has been assigned to this meeting. Meeting Type can no longer be changed.)</small>
         : <button disabled={props.disabled} onClick={props.onShowDialog} type="button" className="btn btn-link">Change</button>;
 
-    const notificationBlurb = (numberInLine && numberInLine > 1)
+    const notificationBlurb = (numberInLine !== null && numberInLine > 1)
         && (
             <Card.Text>
                 <Alert variant="info">

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -42,7 +42,7 @@ export enum MeetingStatus {
 
 export interface Meeting {
     id: number;
-    line_place: number;
+    line_place: number | null;
     attendees: User[];
     agenda: string;
     assignee?: User;
@@ -51,7 +51,6 @@ export interface Meeting {
     created_at: string;
     status: MeetingStatus;
 }
-
 
 export interface QueueBase {
     id: number;

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from django.conf import settings
 from django.db import models
@@ -184,7 +184,7 @@ class Meeting(SafeDeleteModel):
         super().delete(*args, **kwargs)
 
     @property
-    def line_place(self):
+    def line_place(self) -> Optional[int]:
         if not self.queue:
             return None
         meetings = self.queue.meeting_set.order_by('id')

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -191,12 +191,11 @@ class Meeting(SafeDeleteModel):
         unstarted_meetings: List[Meeting] = [
             meeting for meeting in meetings if meeting.status != MeetingStatus.STARTED
         ]
-        if self not in unstarted_meetings:
-            return None
         for i in range(0, len(unstarted_meetings)):
             m = unstarted_meetings[i]
             if m == self:
                 return i
+        return None
 
     def __str__(self):
         return f'{self.id}: {self.backend_type} {self.backend_metadata}'

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import List
 
 from django.conf import settings
 from django.db import models
@@ -187,8 +188,13 @@ class Meeting(SafeDeleteModel):
         if not self.queue:
             return None
         meetings = self.queue.meeting_set.order_by('id')
-        for i in range(0, len(meetings)):
-            m = meetings[i]
+        unstarted_meetings: List[Meeting] = [
+            meeting for meeting in meetings if meeting.status != MeetingStatus.STARTED
+        ]
+        if self not in unstarted_meetings:
+            return None
+        for i in range(0, len(unstarted_meetings)):
+            m = unstarted_meetings[i]
             if m == self:
                 return i
 


### PR DESCRIPTION
Building on the introduction of a `MeetingStatus` `enum` introduced in PR #129, this PR attempts to improve the accuracy of `line_place` information by only assigning a place number if the meeting has not been started (consequently `Meeting.line_place` is left as `None`/`null` for started meetings). The PR aims to resolve issue #244.