### PR TITLE
Prompt 3-legged OAuth on host page only (#241)

### DIFF
--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -21,7 +21,7 @@ import {
 } from "../models";
 import * as api from "../services/api";
 import { useQueueWebSocket, useUserWebSocket } from "../services/sockets";
-import { recordQueueManagementEvent, redirectToBackendAuth, redirectToLogin } from "../utils";
+import { checkBackendAuth, recordQueueManagementEvent, redirectToLogin } from "../utils";
 import { confirmUserExists, uniqnameSchema } from "../validation";
 
 
@@ -257,15 +257,6 @@ const MeetingInfoDialog = (props: MeetingInfoDialogProps) => {
     );
 }
 
-const backendAuthCheck = (user: MyUser, queue: QueueHost) => {
-    for (const backend of queue.allowed_backends) {
-        const authorized = user.authorized_backends[backend];
-        if (authorized === false) {
-            redirectToBackendAuth(backend);
-        }
-    }
-}
-
 interface QueueManagerPageParams {
     queue_id: string;
 }
@@ -301,7 +292,7 @@ export function QueueManagerPage(props: PageProps<QueueManagerPageParams>) {
     const userWebSocketError = useUserWebSocket(props.user!.id, (u) => setMyUser(u as MyUser));
 
     if (myUser && queue) {
-        backendAuthCheck(myUser, queue);
+        checkBackendAuth(myUser, queue);
     }
 
     // Set up API interactions

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -261,7 +261,7 @@ const backendAuthCheck = (user: MyUser, queue: QueueHost) => {
     for (const backend of queue.allowed_backends) {
         const authorized = user.authorized_backends[backend];
         if (authorized === false) {
-            redirectToBackendAuth(backend)
+            redirectToBackendAuth(backend);
         }
     }
 }
@@ -287,9 +287,6 @@ export function QueueManagerPage(props: PageProps<QueueManagerPageParams>) {
         if (!q) {
             setQueue(q);
         } else if (isQueueHost(q)) {
-            if (myUser) {
-                backendAuthCheck(myUser, q);
-            }
             setQueue(q);
             setAuthError(undefined);
         } else {
@@ -301,15 +298,11 @@ export function QueueManagerPage(props: PageProps<QueueManagerPageParams>) {
     const [visibleMeetingDialog, setVisibleMeetingDialog] = useState(undefined as Meeting | undefined);
 
     const [myUser, setMyUser] = useState(undefined as MyUser | undefined);
-    const setMyUserChecked = (u: MyUser | undefined) => {
-        if (u) {
-            if (queue) {
-                backendAuthCheck(u, queue);
-            }
-            setMyUser(u);
-        }
+    const userWebSocketError = useUserWebSocket(props.user!.id, (u) => setMyUser(u as MyUser));
+
+    if (myUser && queue) {
+        backendAuthCheck(myUser, queue);
     }
-    const userWebSocketError = useUserWebSocket(props.user!.id, (u) => setMyUserChecked(u as MyUser));
 
     // Set up API interactions
     const removeMeeting = async (m: Meeting) => {

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -21,6 +21,7 @@ export interface MyUser extends User {
     phone_number: string;
     notify_me_attendee: boolean;
     notify_me_host: boolean;
+    authorized_backends: {[backend: string]: boolean};
 }
 
 export interface BluejeansMetadata {

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -18,6 +18,15 @@ export const redirectToSearch = (term: string) => {
     location.href = `/search/${term}/?redirected=true`;
 }
 
+export const redirectToBackendAuth = (backend: string) => {
+    ReactGA.event({
+        category: "Auth",
+        action: `Redirected to ${backend} Auth`,
+        nonInteraction: true,
+    });
+    location.href = `/auth/${backend}/`;
+}
+
 export const recordQueueManagementEvent = (action: string) => {
     ReactGA.event({
         category: "Queue Management",

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -25,7 +25,7 @@ export const redirectToBackendAuth = (backend: string) => {
         action: `Redirected to ${backend} Auth`,
         nonInteraction: true,
     });
-    location.href = `/auth/${backend}/`;
+    location.href = `/auth/${backend}/?state=${location.pathname}`;
 }
 
 export const checkBackendAuth = (user: MyUser, queue: QueueHost) => {

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -1,4 +1,5 @@
 import * as ReactGA from "react-ga";
+import { MyUser, QueueHost } from "./models";
 
 export const redirectToLogin = (loginUrl: string) => {
     ReactGA.event({
@@ -25,6 +26,15 @@ export const redirectToBackendAuth = (backend: string) => {
         nonInteraction: true,
     });
     location.href = `/auth/${backend}/`;
+}
+
+export const checkBackendAuth = (user: MyUser, queue: QueueHost) => {
+    for (const backend of queue.allowed_backends) {
+        const authorized = user.authorized_backends[backend];
+        if (authorized === false) {
+            redirectToBackendAuth(backend);
+        }
+    }
 }
 
 export const recordQueueManagementEvent = (action: string) => {

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -342,7 +342,6 @@ ZOOM_CLIENT_ID = os.getenv('ZOOM_CLIENT_ID', '').strip()
 ZOOM_CLIENT_SECRET = os.getenv('ZOOM_CLIENT_SECRET', '').strip()
 if ZOOM_CLIENT_ID and ZOOM_CLIENT_SECRET:
     ENABLED_BACKENDS.add("zoom")
-    MIDDLEWARE += ['officehours_api.backends.zoom.ensure_auth']
     DEFAULT_BACKEND = "zoom"
 
 DEFAULT_ALLOWED_BACKENDS = (

--- a/src/officehours_api/backends/bluejeans.py
+++ b/src/officehours_api/backends/bluejeans.py
@@ -189,3 +189,7 @@ class Backend:
             'docs_url': self.docs_url,
             'telephone_num': self.telephone_num
         }
+    
+    @classmethod
+    def is_authorized(cls, user: User) -> bool:
+        return True

--- a/src/officehours_api/backends/bluejeans.py
+++ b/src/officehours_api/backends/bluejeans.py
@@ -182,12 +182,12 @@ class Backend:
         return backend_metadata
 
     @classmethod
-    def get_public_data(self) -> BackendDict:
+    def get_public_data(cls) -> BackendDict:
         return {
-            'name': self.name,
-            'friendly_name': self.friendly_name,
-            'docs_url': self.docs_url,
-            'telephone_num': self.telephone_num
+            'name': cls.name,
+            'friendly_name': cls.friendly_name,
+            'docs_url': cls.docs_url,
+            'telephone_num': cls.telephone_num
         }
     
     @classmethod

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -20,3 +20,7 @@ class Backend:
             'docs_url': self.docs_url,
             'telephone_num': self.telephone_num
         }
+
+    @classmethod
+    def is_authorized(cls, user: User) -> bool:
+        return True

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -13,12 +13,12 @@ class Backend:
         return {'started': True}
 
     @classmethod
-    def get_public_data(self) -> BackendDict:
+    def get_public_data(cls) -> BackendDict:
         return {
-            'name': self.name,
-            'friendly_name': self.friendly_name,
-            'docs_url': self.docs_url,
-            'telephone_num': self.telephone_num
+            'name': cls.name,
+            'friendly_name': cls.friendly_name,
+            'docs_url': cls.docs_url,
+            'telephone_num': cls.telephone_num
         }
 
     @classmethod

--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -215,18 +215,3 @@ class Backend:
             'docs_url': self.docs_url,
             'telephone_num': self.telephone_num
         }
-
-
-def ensure_auth(get_response):
-    def middleware(request):
-        if not request.user.is_authenticated:
-            return get_response(request)
-        if request.user.profile.backend_metadata.get('zoom', None):
-            return get_response(request)
-        auth_prompt_path = reverse('auth_prompt', kwargs={'backend_name': 'zoom'})
-        auth_callback_path = reverse('auth_callback', kwargs={'backend_name': 'zoom'})
-        if request.path in (auth_prompt_path, auth_callback_path):
-            return get_response(request)
-        logger.debug("Redirecting %s from %s to %s", request.user.username, request.path, auth_prompt_path)
-        return redirect(auth_prompt_path)
-    return middleware

--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -208,10 +208,14 @@ class Backend:
         )
 
     @classmethod
-    def get_public_data(self) -> BackendDict:
+    def get_public_data(cls) -> BackendDict:
         return {
-            'name': self.name,
-            'friendly_name': self.friendly_name,
-            'docs_url': self.docs_url,
-            'telephone_num': self.telephone_num
+            'name': cls.name,
+            'friendly_name': cls.friendly_name,
+            'docs_url': cls.docs_url,
+            'telephone_num': cls.telephone_num
         }
+    
+    @classmethod
+    def is_authorized(cls, user: User) -> bool:
+        return bool(user.profile.backend_metadata.get('zoom'))

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -14,7 +14,7 @@ from jsonfield import JSONField
 from requests.exceptions import RequestException
 from officehours_api import backends
 
-backend_instances = {
+BACKEND_INSTANCES = {
     backend_name: getattr(getattr(backends, backend_name), 'Backend')()
     for backend_name in settings.ENABLED_BACKENDS
 }
@@ -65,7 +65,7 @@ def get_default_allowed_backends():
 def get_backend_types():
     return [
         [key, value.friendly_name]
-        for key, value in backend_instances.items()
+        for key, value in BACKEND_INSTANCES.items()
     ]
 
 class Queue(SafeDeleteModel):
@@ -156,7 +156,7 @@ class Meeting(SafeDeleteModel):
             self.assignee = assignee
         if not self.assignee:
             raise Exception("Can't start meeting before assignee is set!")
-        backend = backend_instances[self.backend_type]
+        backend = BACKEND_INSTANCES[self.backend_type]
         user_email = self.queue.hosts.first().email
         self.backend_metadata['user_email'] = user_email
         try:

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -41,6 +41,13 @@ class Profile(models.Model):
     notify_me_host = models.BooleanField(default=False)
     backend_metadata = JSONField(null=True, default=dict)
 
+    @property
+    def authorized_backends(self):
+        return {
+            backend.name: backend.is_authorized(self.user)
+            for backend in backend_instances.values()
+        }
+
     def __str__(self):
         return f'user={self.user.username}'
 

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -86,12 +86,13 @@ class MyUserSerializer(serializers.ModelSerializer):
     phone_number = serializers.CharField(source='profile.phone_number', allow_blank=True)
     notify_me_attendee = serializers.BooleanField(source='profile.notify_me_attendee')
     notify_me_host = serializers.BooleanField(source='profile.notify_me_host')
+    authorized_backends = serializers.DictField(source='profile.authorized_backends')
 
     class Meta:
         model = User
         fields = [
-            'id', 'username', 'email', 'first_name', 'last_name', 'my_queue',
-            'hosted_queues', 'phone_number', 'notify_me_attendee', 'notify_me_host'
+            'id', 'username', 'email', 'first_name', 'last_name', 'my_queue', 'hosted_queues',
+            'phone_number', 'notify_me_attendee', 'notify_me_host', 'authorized_backends',
         ]
 
     def get_my_queue(self, obj):

--- a/src/officehours_ui/views.py
+++ b/src/officehours_ui/views.py
@@ -21,11 +21,12 @@ class AuthPromptView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         backend_name = kwargs['backend_name']
+        state = self.request.GET.get('state', '/')
         try:
             redirect_uri = self.request.build_absolute_uri(
                 reverse('auth_callback', kwargs={'backend_name': backend_name})
             )
-            context['auth_url'] = BACKEND_CLASSES[backend_name].get_auth_url(redirect_uri)
+            context['auth_url'] = BACKEND_CLASSES[backend_name].get_auth_url(redirect_uri, state)
         except KeyError:
             raise Http404(f"Backend {backend_name} does not exist.")
         except AttributeError:


### PR DESCRIPTION
Instead of redirecting to authorize Zoom upon any page view, only redirect when they visit the `/manage/{id}` route, and only if Zoom is an enabled backend for that queue. This solution should gracefully handle situations where an existing queue has Zoom enabled while hosts are on the page. 

Closes #241