### PR TITLE
Send notification on Meeting start (#226)

### DIFF
--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -140,6 +140,7 @@ class Meeting(SafeDeleteModel):
         super(Meeting, self).__init__(*args, **kwargs)
         self._original_backend_type = self.backend_type
         self._original_assignee = self.assignee
+        self._original_status = self.status
 
     @property
     def status(self):

--- a/src/officehours_api/notifications.py
+++ b/src/officehours_api/notifications.py
@@ -24,12 +24,12 @@ def build_addendum(domain: str):
     )
 
 
-def notify_meeting_started(next_in_line: Meeting):
+def notify_meeting_started(started: Meeting):
     phone_numbers = list(
         u.profile.phone_number for u in
-        next_in_line.attendees_with_phone_numbers.filter(profile__notify_me_attendee__exact=True)
+        started.attendees_with_phone_numbers.filter(profile__notify_me_attendee__exact=True)
     )
-    queue_path = reverse('queue', kwargs={'queue_id': next_in_line.queue.id})
+    queue_path = reverse('queue', kwargs={'queue_id': started.queue.id})
     domain = Site.objects.get_current().domain
     queue_url = f"{domain}{queue_path}"
     for p in phone_numbers:
@@ -44,7 +44,7 @@ def notify_meeting_started(next_in_line: Meeting):
                 ),
             )
         except:
-            logger.exception(f"Error while sending attendee notification to {p} for queue {next_in_line.queue.id}")
+            logger.exception(f"Error while sending attendee notification to {p} for queue {started.queue.id}")
 
 
 def notify_queue_no_longer_empty(first: Meeting):

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -93,7 +93,7 @@ class MyUserSerializer(serializers.ModelSerializer):
     phone_number = serializers.CharField(source='profile.phone_number', allow_blank=True)
     notify_me_attendee = serializers.BooleanField(source='profile.notify_me_attendee')
     notify_me_host = serializers.BooleanField(source='profile.notify_me_host')
-    authorized_backends = serializers.DictField(source='profile.authorized_backends')
+    authorized_backends = serializers.DictField(source='profile.authorized_backends', read_only=True)
 
     class Meta:
         model = User


### PR DESCRIPTION
Send a Notification to an Attendee when their Meeting is started (backend meeting is created), rather than when their `line_place` changes to 1.
Closes #226 