### PR TITLE
Auto-assign for single-host queues (#227)

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -18,7 +18,7 @@ import { PageProps } from "./page";
 import { usePromise } from "../hooks/usePromise";
 import * as api from "../services/api";
 import { useQueueWebSocket, useUserWebSocket } from "../services/sockets";
-import { redirectToLogin } from "../utils";
+import { addMeetingAutoAssigned, redirectToLogin } from "../utils";
 import { meetingAgendaSchema } from "../validation";
 
 
@@ -417,7 +417,7 @@ export function QueuePage(props: PageProps<QueuePageParams>) {
             category: "Attending",
             action: "Joined Queue",
         });
-        await api.addMeeting(queueIdParsed, props.user!.id, backendType);
+        await addMeetingAutoAssigned(queue!, props.user!.id, backendType);
     }
     const [doJoinQueue, joinQueueLoading, joinQueueError] = usePromise(joinQueue);
     const leaveQueue = async () => {
@@ -448,7 +448,7 @@ export function QueuePage(props: PageProps<QueuePageParams>) {
             action: "Left Previous Queue and Joined New Queue",
         });
         await api.removeMeeting(myUser!.my_queue!.my_meeting!.id);
-        await api.addMeeting(queueIdParsed, props.user!.id, backendType);
+        await addMeetingAutoAssigned(queue!, props.user!.id, backendType);
     }
     const [doLeaveAndJoinQueue, leaveAndJoinQueueLoading, leaveAndJoinQueueError] = usePromise(leaveAndJoinQueue);
     const changeAgenda = async (agenda: string) => {

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -21,7 +21,7 @@ import {
 } from "../models";
 import * as api from "../services/api";
 import { useQueueWebSocket, useUserWebSocket } from "../services/sockets";
-import { checkBackendAuth, recordQueueManagementEvent, redirectToLogin } from "../utils";
+import { addMeetingAutoAssigned, checkBackendAuth, recordQueueManagementEvent, redirectToLogin } from "../utils";
 import { confirmUserExists, uniqnameSchema } from "../validation";
 
 
@@ -312,7 +312,7 @@ export function QueueManagerPage(props: PageProps<QueueManagerPageParams>) {
     const addMeeting = async (uniqname: string, backend: string) => {
         const user = await confirmUserExists(uniqname);
         recordQueueManagementEvent("Added Meeting");
-        await api.addMeeting(queue!.id, user.id, backend);
+        await addMeetingAutoAssigned(queue!, props.user!.id, backend);
     }
     const [doAddMeeting, addMeetingLoading, addMeetingError] = usePromise(addMeeting);
 

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -312,7 +312,7 @@ export function QueueManagerPage(props: PageProps<QueueManagerPageParams>) {
     const addMeeting = async (uniqname: string, backend: string) => {
         const user = await confirmUserExists(uniqname);
         recordQueueManagementEvent("Added Meeting");
-        await addMeetingAutoAssigned(queue!, props.user!.id, backend);
+        await addMeetingAutoAssigned(queue!, user.id, backend);
     }
     const [doAddMeeting, addMeetingLoading, addMeetingError] = usePromise(addMeeting);
 

--- a/src/assets/src/services/api.ts
+++ b/src/assets/src/services/api.ts
@@ -122,13 +122,13 @@ export const deleteQueue = async (id: number) => {
     return resp;
 }
 
-export const addMeeting = async (queue_id: number, user_id: number, backend_type: string) => {
+export const addMeeting = async (queue_id: number, user_id: number, backend_type: string, assignee_id?: number) => {
     const resp = await fetch("/api/meetings/", {
         method: "POST",
         body: JSON.stringify({
             queue: queue_id,
             attendee_ids: [user_id],
-            assignee_id: null,
+            assignee_id: assignee_id ?? null,
             backend_type: backend_type,
         }),
         headers: getPostHeaders(),

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -1,5 +1,6 @@
 import * as ReactGA from "react-ga";
-import { MyUser, QueueHost } from "./models";
+import { MyUser, QueueFull, QueueHost } from "./models";
+import * as api from "./services/api";
 
 export const redirectToLogin = (loginUrl: string) => {
     ReactGA.event({
@@ -57,4 +58,11 @@ export function checkIfSetsAreDifferent(setA: Set<any>, setB: Set<any>) {
         }
     }
     return !!difference.size;
+}
+
+export const addMeetingAutoAssigned = async (queue: QueueFull, userId: number, backendType: string) => {
+    const assignee = queue!.hosts.length === 1
+            ? queue!.hosts[0].id
+            : undefined;
+    await api.addMeeting(queue.id, userId, backendType, assignee);
 }

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -61,8 +61,8 @@ export function checkIfSetsAreDifferent(setA: Set<any>, setB: Set<any>) {
 }
 
 export const addMeetingAutoAssigned = async (queue: QueueFull, userId: number, backendType: string) => {
-    const assignee = queue!.hosts.length === 1
-            ? queue!.hosts[0].id
+    const assignee = queue.hosts.length === 1
+            ? queue.hosts[0].id
             : undefined;
     await api.addMeeting(queue.id, userId, backendType, assignee);
 }


### PR DESCRIPTION
Auto-assigns new meetings in single-host queues; otherwise, retains old behavior.
Closes #227 