### PR TITLE
Refactor meeting info components, adjust language and conditional logic for JIT meeting creation (#233, #235, #247)

### DIFF
--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -443,7 +443,7 @@ export const LoginDialog = (props: LoginDialogProps) =>
 
 interface OneTouchDialLinkProps {
     phone: string; // "." delimited
-    meetingNumber?: string;
+    meetingNumber: string;
 }
 
 const OneTouchDialLink = (props: OneTouchDialLinkProps) => (
@@ -465,7 +465,6 @@ const IntlTelephoneLink = (props: IntlTelephoneLinkProps) =>  {
 }
 
 export type DialInMessageProps = OneTouchDialLinkProps & IntlTelephoneLinkProps;
-const meetingNumberPlaceholder = 'the meeting number (that will appear here once the meeting is created) followed by ';
 
 export const BlueJeansDialInMessage = (props: DialInMessageProps) => {
     const phoneLinkUsa = <OneTouchDialLink {...props} />;
@@ -473,7 +472,7 @@ export const BlueJeansDialInMessage = (props: DialInMessageProps) => {
         <span>
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
             (or <IntlTelephoneLink {...props} />)
-            from any phone and enter {props.meetingNumber ?? meetingNumberPlaceholder}#.
+            from any phone and enter {props.meetingNumber}#.
             You are not a moderator, so you do not need a moderator passcode.
         </span>
     );
@@ -485,7 +484,7 @@ export const ZoomDialInMessage = (props: DialInMessageProps) => {
         <span>
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
             (or <IntlTelephoneLink {...props} /> - click See All Numbers under Toll Call to see all countries)
-            from any phone and enter {props.meetingNumber ?? meetingNumberPlaceholder}#.
+            from any phone and enter {props.meetingNumber}#.
             You do not need a host key or participant ID.
         </span>
     );

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -3,7 +3,7 @@ import { createRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSyncAlt, faClipboard, faClipboardCheck, faPencilAlt, faTrashAlt, faHome } from '@fortawesome/free-solid-svg-icons';
-import { Alert, Badge, Breadcrumb, Button, Form, FormControl, InputGroup, Modal, Table } from "react-bootstrap";
+import { Alert, Badge, Breadcrumb, Button, Form, InputGroup, Modal, Table } from "react-bootstrap";
 import Dialog from "react-bootstrap-dialog";
 import { StringSchema } from "yup";
 

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -456,7 +456,7 @@ interface IntlTelephoneLinkProps {
     intlNumbersURL: string;
 }
 
-const IntlTelephoneLink = (props: IntlTelephoneLinkProps) =>  {
+const IntlTelephoneLink = (props: IntlTelephoneLinkProps) => {
     return (
         <a target="_blank" href={props.intlNumbersURL}>
             find your international number to call in from outside the USA
@@ -483,7 +483,7 @@ export const ZoomDialInMessage = (props: DialInMessageProps) => {
     return (
         <span>
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
-            (or <IntlTelephoneLink {...props} /> - click See All Numbers under Toll Call to see all countries)
+            (or <IntlTelephoneLink {...props} /> -- click See All Numbers under Toll Call to see all countries)
             from any phone and enter {props.meetingNumber}#.
             You do not need a host key or participant ID.
         </span>

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -443,7 +443,7 @@ export const LoginDialog = (props: LoginDialogProps) =>
 
 interface OneTouchDialLinkProps {
     phone: string; // "." delimited
-    meetingNumber: string;
+    meetingNumber?: string;
 }
 
 const OneTouchDialLink = (props: OneTouchDialLinkProps) => (
@@ -465,6 +465,7 @@ const IntlTelephoneLink = (props: IntlTelephoneLinkProps) =>  {
 }
 
 export type DialInMessageProps = OneTouchDialLinkProps & IntlTelephoneLinkProps;
+const meetingNumberPlaceholder = 'the meeting number (that will appear here once the meeting is created) followed by ';
 
 export const BlueJeansDialInMessage = (props: DialInMessageProps) => {
     const phoneLinkUsa = <OneTouchDialLink {...props} />;
@@ -472,7 +473,7 @@ export const BlueJeansDialInMessage = (props: DialInMessageProps) => {
         <span>
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
             (or <IntlTelephoneLink {...props} />)
-            from any phone and enter {props.meetingNumber}#.
+            from any phone and enter {props.meetingNumber ?? meetingNumberPlaceholder}#.
             You are not a moderator, so you do not need a moderator passcode.
         </span>
     );
@@ -484,7 +485,7 @@ export const ZoomDialInMessage = (props: DialInMessageProps) => {
         <span>
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
             (or <IntlTelephoneLink {...props} /> - click See All Numbers under Toll Call to see all countries)
-            from any phone and enter {props.meetingNumber}#.
+            from any phone and enter {props.meetingNumber ?? meetingNumberPlaceholder}#.
             You do not need a host key or participant ID.
         </span>
     );

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -473,6 +473,7 @@ export const BlueJeansDialInMessage = (props: DialInMessageProps) => {
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
             (or <IntlTelephoneLink {...props} />)
             from any phone and enter {props.meetingNumber}#.
+            You are not a moderator, so you do not need a moderator passcode.
         </span>
     );
 }

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -473,7 +473,7 @@ export const BlueJeansDialInMessage = (props: DialInMessageProps) => {
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
             (or <IntlTelephoneLink {...props} />)
             from any phone and enter {props.meetingNumber}#.
-            You are not a moderator, so you do not need a moderator passcode.
+            You do not need a passcode to join the meeting.
         </span>
     );
 }

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -441,29 +441,52 @@ export const LoginDialog = (props: LoginDialogProps) =>
     </Modal>
 
 
-interface BlueJeansOneTouchDialLinkProps {
+interface OneTouchDialLinkProps {
     phone: string; // "." delimited
     meetingNumber: string;
 }
 
-export const BlueJeansOneTouchDialLink = (props: BlueJeansOneTouchDialLinkProps) => 
+const OneTouchDialLink = (props: OneTouchDialLinkProps) => (
     <a href={`tel:${props.phone.replace(".", "")},,,${props.meetingNumber},%23,%23`}>
         {props.phone}
     </a>
+);
 
-interface BlueJeansDialInMessageProps {
-    meetingNumber: string;
+interface IntlTelephoneLinkProps {
+    intlNumbersURL: string;
 }
 
-export const BlueJeansDialInMessage = (props: BlueJeansDialInMessageProps) => {
-    const phoneLinkUsa = <BlueJeansOneTouchDialLink phone="1.312.216.0325" meetingNumber={props.meetingNumber} />
+const IntlTelephoneLink = (props: IntlTelephoneLinkProps) =>  {
+    return (
+        <a target="_blank" href={props.intlNumbersURL}>
+            find your international number to call in from outside the USA
+        </a>
+    );
+}
+
+export type DialInMessageProps = OneTouchDialLinkProps & IntlTelephoneLinkProps;
+
+export const BlueJeansDialInMessage = (props: DialInMessageProps) => {
+    const phoneLinkUsa = <OneTouchDialLink {...props} />;
     return (
         <span>
-            Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA 
-            (or <a target="_blank" href="https://www.bluejeans.com/premium-numbers"> find your international number to call in from outside the USA</a>) 
+            Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
+            (or <IntlTelephoneLink {...props} />)
             from any phone and enter {props.meetingNumber}#.
         </span>
-    )
+    );
+}
+
+export const ZoomDialInMessage = (props: DialInMessageProps) => {
+    const phoneLinkUsa = <OneTouchDialLink {...props} />;
+    return (
+        <span>
+            Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
+            (or <IntlTelephoneLink {...props} /> - click See All Numbers under Toll Call to see all countries)
+            from any phone and enter {props.meetingNumber}#.
+            You do not need a host key or participant ID.
+        </span>
+    );
 }
 
 interface BreadcrumbsProps {

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -235,7 +235,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
             <Alert variant="info">
                 <small>
                     Did you know? You can receive an SMS (text) message when
-                    it's your turn by by adding your cell phone number and
+                    it's your turn by adding your cell phone number and
                     enabling attendee notifications in
                     your <Link to="/preferences">User Preferences</Link>.
                 </small>

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -231,7 +231,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
                 Join Meeting
             </Button>
         )
-        : <p><strong>Please wait. The meeting is being started...</strong></p>;
+        : <span><strong>Please wait. A Join Meeting button will appear here.</strong></span>;
 
     const changeMeetingType = props.queue.my_meeting?.assignee
         ? <small className="ml-2">(A Host has been assigned to this meeting. Meeting Type can no longer be changed.)</small>

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -155,17 +155,20 @@ const VideoMeetingInfo: React.FC<VideoMeetingInfoProps> = (props) => {
         </a>
     );
 
-    const dialInProps = {
-        phone: props.backend.telephone_num,
-        meetingNumber: props.metadata.numeric_meeting_id,
-        intlNumbersURL: props.backend.intl_telephone_url
-    } as DialInMessageProps;
+    let dialInMessage;
+    if (props.metadata.numeric_meeting_id) {
+        const dialInProps = {
+            phone: props.backend.telephone_num,
+            meetingNumber: props.metadata.numeric_meeting_id,
+            intlNumbersURL: props.backend.intl_telephone_url
+        } as DialInMessageProps;
 
-    const dialInMessage = props.backend.name === 'zoom'
-        ? <ZoomDialInMessage {...dialInProps} />
-        : props.backend.name === 'bluejeans'
-            ? <BlueJeansDialInMessage {...dialInProps} />
-            : null;
+        dialInMessage = props.backend.name === 'zoom'
+            ? <ZoomDialInMessage {...dialInProps} />
+            : props.backend.name === 'bluejeans'
+                ? <BlueJeansDialInMessage {...dialInProps} />
+                : null;
+    }
 
     return (
         <>

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -232,16 +232,14 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
 
     const notificationBlurb = (numberInLine !== null && numberInLine > 1)
         && (
-            <Card.Text>
-                <Alert variant="info">
-                    <small>
-                        Did you know? You can receive an SMS (text) message when 
-                        it's your turn by by adding your cell phone number and 
-                        enabling attendee notifications in 
-                        your <Link to="/preferences">User Preferences</Link>.
-                    </small>
-                </Alert>
-            </Card.Text>
+            <Alert variant="info">
+                <small>
+                    Did you know? You can receive an SMS (text) message when
+                    it's your turn by by adding your cell phone number and
+                    enabling attendee notifications in
+                    your <Link to="/preferences">User Preferences</Link>.
+                </small>
+            </Alert>
         );
 
     const agendaBlock = !inProgress

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -6,7 +6,8 @@ import { Alert, Button, Card, Col, Modal, Row } from "react-bootstrap";
 import Dialog from "react-bootstrap-dialog";
 
 import {
-    BluejeansMetadata, EnabledBackendName, MeetingBackend, MeetingStatus, MyUser, QueueAttendee, User, ZoomMetadata
+    BluejeansMetadata, EnabledBackendName, MeetingBackend, MeetingStatus, MyUser, QueueAttendee,
+    User, VideoBackendNames, ZoomMetadata
 } from "../models";
 import {
     checkForbiddenError, BlueJeansDialInMessage, Breadcrumbs, DateTimeDisplay, DialInMessageProps,
@@ -187,10 +188,7 @@ const VideoMeetingInfo: React.FC<VideoMeetingInfoProps> = (props) => {
                         <Card>
                             <Card.Body>
                                 <Card.Title className='mt-0'>Having Trouble with Video?</Card.Title>
-                                <Card.Text>
-                                    {dialInMessage}
-                                    You are not a moderator, so you do not need a moderator passcode.
-                                </Card.Text>
+                                <Card.Text>{dialInMessage}</Card.Text>
                             </Card.Body>
                         </Card>
                     </Col>
@@ -212,7 +210,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         ? <MeetingReadyAlert meetingType={meetingBackend.name} />
         : <WaitingTurnAlert meetingType={meetingBackend.name} placeInLine={numberInLine!}/>;
 
-    const meetingInfo = (['bluejeans', 'zoom'].includes(meetingBackend.name) && inProgress)
+    const meetingInfo = (VideoBackendNames.includes(meetingBackend.name) && inProgress)
         && <VideoMeetingInfo metadata={meeting.backend_metadata!} backend={meetingBackend} />;
 
     const leave = (

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -228,7 +228,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
     // Card content
     const changeMeetingType = props.queue.my_meeting?.assignee
         ? <small className="ml-2">(A Host has been assigned to this meeting. Meeting Type can no longer be changed.)</small>
-        : <button disabled={props.disabled} onClick={props.onShowDialog} type="button" className="btn btn-link">Change</button>;
+        : <Button variant='link' onClick={props.onShowDialog} aria-label='Change Meeting Type' disabled={props.disabled}>Change</Button>;
 
     const notificationBlurb = (numberInLine !== null && numberInLine > 1)
         && (
@@ -266,14 +266,16 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
         : <Card.Text><strong>Meeting Agenda</strong>: {meeting.agenda ? meeting.agenda : 'None'}</Card.Text>;
 
     // Meeting actions and info
+    const leaveButtonText = inProgress ? 'Cancel My Meeting' : 'Leave the Line';
     const leave = (
         <Button
             variant='link'
             type='button'
-            disabled={props.disabled}
             onClick={() => props.onLeaveQueue()}
+            disabled={props.disabled}
+            aria-label={leaveButtonText}
         >
-            {inProgress ? 'Cancel My Meeting' : 'Leave the Line'}
+            {leaveButtonText}
             {props.disabled && DisabledMessage}
         </Button>
     );
@@ -290,7 +292,14 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
     const joinLink = isVideoMeeting && (
         meeting.backend_metadata!.meeting_url
             ? (
-                <Button as='a' href={meeting.backend_metadata!.meeting_url} target='_blank' variant='warning' className='mr-3'>
+                <Button
+                    href={meeting.backend_metadata!.meeting_url}
+                    target='_blank'
+                    variant='warning'
+                    className='mr-3'
+                    aria-label='Join Meeting'
+                    disabled={props.disabled}
+                >
                     Join Meeting
                 </Button>
             )

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -173,7 +173,7 @@ const VideoMeetingInfo: React.FC<VideoMeetingInfoProps> = (props) => {
             <Col md={6} sm={true}>
                 <Card>
                     <Card.Body>
-                        <Card.Title as='h5' className='mt-0'>Join the Meeting</Card.Title>
+                        <Card.Title as='h5' className='mt-0'>Joining the Meeting</Card.Title>
                         <Card.Text>
                             Once the meeting is created, click Join Meeting to join the meeting and wait for the host.
                             Download the app and test your audio now.

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -220,7 +220,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
             disabled={props.disabled}
             onClick={() => props.onLeaveQueue()}
         >
-            Leave the line
+            {inProgress ? 'Cancel My Meeting' : 'Leave the Line'}
             {props.disabled && DisabledMessage}
         </Button>
     );

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -296,8 +296,7 @@ function QueueAttendingJoined(props: QueueAttendingProps) {
             : <span><strong>Please wait. A Join Meeting button will appear here.</strong></span>
     );
 
-    const meetingInfo = (isVideoMeeting && inProgress)
-        && <VideoMeetingInfo metadata={meeting.backend_metadata!} backend={meetingBackend} />;
+    const meetingInfo = isVideoMeeting && <VideoMeetingInfo metadata={meeting.backend_metadata!} backend={meetingBackend} />;
 
     return (
         <>

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -9,7 +9,7 @@ import Dialog from "react-bootstrap-dialog";
 import {
     UserDisplay, ErrorDisplay, FormError, checkForbiddenError, LoadingDisplay, DateDisplay,
     CopyField, showConfirmation, LoginDialog, Breadcrumbs, DateTimeDisplay, BlueJeansDialInMessage,
-    userLoggedOnWarning
+    userLoggedOnWarning, DialInMessageProps, ZoomDialInMessage
 } from "./common";
 import { MeetingsInProgressTable, MeetingsInQueueTable } from "./meetingTables";
 import { BackendSelector as MeetingBackendSelector, getBackendByName } from "./meetingType";
@@ -192,17 +192,28 @@ function QueueManager(props: QueueManagerProps) {
 }
 
 interface HostVideoMeetingInfoProps {
-    meetingBackend: MeetingBackend;
     metadata: BluejeansMetadata | ZoomMetadata;
+    backend: MeetingBackend;
 }
 
  // Zoom Dial-in info will be added here soon.
 const HostVideoMeetingInfo = (props: HostVideoMeetingInfoProps) => {
-    const meetingNumber = props.metadata.numeric_meeting_id;
+    const dialInProps = {
+        phone: props.backend.telephone_num,
+        meetingNumber: props.metadata.numeric_meeting_id,
+        intlNumbersURL: props.backend.intl_telephone_url
+    } as DialInMessageProps;
+
+    const dialInMessage = props.backend.name === 'zoom'
+        ? <ZoomDialInMessage {...dialInProps} />
+        : props.backend.name === 'bluejeans'
+            ? <BlueJeansDialInMessage {...dialInProps} />
+            : null;
+
     return (
         <>
-        <p>This meeting will be via <strong>{props.meetingBackend.friendly_name}</strong>.</p>
-        {props.meetingBackend.name === 'bluejeans' && <p><BlueJeansDialInMessage meetingNumber={meetingNumber} /></p>}
+        <p>This meeting will be via <strong>{props.backend.friendly_name}</strong>.</p>
+        {dialInMessage}
         </>
     );
 }
@@ -235,7 +246,7 @@ const MeetingInfoDialog = (props: MeetingInfoDialogProps) => {
             ['bluejeans', 'zoom'].includes(meetingType)
                 ? (
                     <HostVideoMeetingInfo
-                        meetingBackend={getBackendByName(meetingType, props.backends)}
+                        backend={getBackendByName(meetingType, props.backends)}
                         metadata={props.meeting!.backend_metadata!}
                     />
                 ) : <div><p>This meeting will be <strong>In Person</strong>.</p></div>

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -198,17 +198,20 @@ interface HostVideoMeetingInfoProps {
 }
 
 const HostVideoMeetingInfo = (props: HostVideoMeetingInfoProps) => {
-    const dialInProps = {
-        phone: props.backend.telephone_num,
-        meetingNumber: props.metadata.numeric_meeting_id,
-        intlNumbersURL: props.backend.intl_telephone_url
-    } as DialInMessageProps;
+    let dialInMessage;
+    if (props.metadata.numeric_meeting_id) {
+        const dialInProps = {
+            phone: props.backend.telephone_num,
+            meetingNumber: props.metadata.numeric_meeting_id,
+            intlNumbersURL: props.backend.intl_telephone_url
+        } as DialInMessageProps;
 
-    const dialInMessage = props.backend.name === 'zoom'
-        ? <ZoomDialInMessage {...dialInProps} />
-        : props.backend.name === 'bluejeans'
-            ? <BlueJeansDialInMessage {...dialInProps} />
-            : null;
+        dialInMessage = props.backend.name === 'zoom'
+            ? <ZoomDialInMessage {...dialInProps} />
+            : props.backend.name === 'bluejeans'
+                ? <BlueJeansDialInMessage {...dialInProps} />
+                : null;
+    }
 
     return (
         <>

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -17,7 +17,8 @@ import { PageProps } from "./page";
 import { usePromise } from "../hooks/usePromise";
 import { useStringValidation } from "../hooks/useValidation";
 import {
-    BluejeansMetadata, isQueueHost, Meeting, MeetingBackend, MeetingStatus, QueueAttendee, QueueHost, User, MyUser, ZoomMetadata
+    BluejeansMetadata, isQueueHost, Meeting, MeetingBackend, MeetingStatus, MyUser, QueueAttendee, QueueHost,
+    User, VideoBackendNames, ZoomMetadata
 } from "../models";
 import * as api from "../services/api";
 import { useQueueWebSocket, useUserWebSocket } from "../services/sockets";
@@ -196,7 +197,7 @@ interface HostVideoMeetingInfoProps {
     backend: MeetingBackend;
 }
 
- // Zoom Dial-in info will be added here soon.
+
 const HostVideoMeetingInfo = (props: HostVideoMeetingInfoProps) => {
     const dialInProps = {
         phone: props.backend.telephone_num,
@@ -243,7 +244,7 @@ const MeetingInfoDialog = (props: MeetingInfoDialogProps) => {
     const meetingType = props.meeting?.backend_type
     const metadataInfo = meetingType
         && (
-            ['bluejeans', 'zoom'].includes(meetingType)
+            VideoBackendNames.includes(meetingType)
                 ? (
                     <HostVideoMeetingInfo
                         backend={getBackendByName(meetingType, props.backends)}

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -197,7 +197,6 @@ interface HostVideoMeetingInfoProps {
     backend: MeetingBackend;
 }
 
-
 const HostVideoMeetingInfo = (props: HostVideoMeetingInfoProps) => {
     const dialInProps = {
         phone: props.backend.telephone_num,

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -1,5 +1,7 @@
 export type EnabledBackendName = 'zoom' | 'bluejeans' | 'inperson';
 
+export const VideoBackendNames: EnabledBackendName[] = ['zoom', 'bluejeans'];
+
 export interface MeetingBackend {
     name: EnabledBackendName;
     friendly_name: string;

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -5,6 +5,7 @@ export interface MeetingBackend {
     friendly_name: string;
     docs_url: string | null;
     telephone_num: string | null;
+    intl_telephone_url: string | null;
 }
 
 export interface User {

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -324,10 +324,12 @@ TWILIO_MESSAGING_SERVICE_SID = os.getenv('TWILIO_MESSAGING_SERVICE_SID')
 DOCS_BASE_URL = 'https://its.umich.edu/communication/videoconferencing/'
 
 ZOOM_DOCS_URL = os.getenv('ZOOM_DOCS_URL', DOCS_BASE_URL + 'zoom')
-ZOOM_TELE_NUM = os.getenv('ZOOM_TELE_NUM')
+ZOOM_TELE_NUM = os.getenv('ZOOM_TELE_NUM', '1.312.626.6799')
+ZOOM_INTL_URL = os.getenv('ZOOM_INTL_URL', 'https://umich.zoom.us/profile/setting?tab=telephony')
 
 BLUEJEANS_DOCS_URL = os.getenv('BLUEJEANS_DOCS_URL', DOCS_BASE_URL + 'blue-jeans/getting-started')
 BLUEJEANS_TELE_NUM = os.getenv('BLUEJEANS_TELE_NUM', '1.312.216.0325')
+BLUEJEANS_INTL_URL = os.getenv('BLUEJEANS_INTL_URL', 'https://www.bluejeans.com/premium-numbers')
 
 ENABLED_BACKENDS = {'inperson'}
 DEFAULT_BACKEND = "inperson"

--- a/src/officehours_api/backends/backend_dict.py
+++ b/src/officehours_api/backends/backend_dict.py
@@ -6,3 +6,4 @@ class BackendDict(TypedDict):
     friendly_name: str
     docs_url: Optional[str]
     telephone_num: Optional[str]
+    intl_telephone_url: Optional[str]

--- a/src/officehours_api/backends/bluejeans.py
+++ b/src/officehours_api/backends/bluejeans.py
@@ -131,8 +131,9 @@ class BluejeansClient:
 class Backend:
     name: str = 'bluejeans'
     friendly_name: str = 'BlueJeans'
-    docs_url: Optional[str] = settings.BLUEJEANS_DOCS_URL
-    telephone_num: Optional[str] = settings.BLUEJEANS_TELE_NUM
+    docs_url: str = settings.BLUEJEANS_DOCS_URL
+    telephone_num: str = settings.BLUEJEANS_TELE_NUM
+    intl_telephone_url: str = settings.BLUEJEANS_INTL_URL
 
     _client: BluejeansClient
 
@@ -187,7 +188,8 @@ class Backend:
             'name': cls.name,
             'friendly_name': cls.friendly_name,
             'docs_url': cls.docs_url,
-            'telephone_num': cls.telephone_num
+            'telephone_num': cls.telephone_num,
+            'intl_telephone_url': cls.intl_telephone_url
         }
     
     @classmethod

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -20,7 +20,7 @@ class Backend:
             'friendly_name': cls.friendly_name,
             'docs_url': cls.docs_url,
             'telephone_num': cls.telephone_num,
-            'intl_telephone_num': cls.intl_telephone_url
+            'intl_telephone_url': cls.intl_telephone_url
         }
 
     @classmethod

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -8,7 +8,7 @@ class Backend:
     friendly_name = "In Person"
     docs_url = None
     telephone_num = None
-    intl_telephone_num = None
+    intl_telephone_url = None
 
     def save_user_meeting(self, backend_metadata: dict, assignee: User):
         return {'started': True}
@@ -20,7 +20,7 @@ class Backend:
             'friendly_name': cls.friendly_name,
             'docs_url': cls.docs_url,
             'telephone_num': cls.telephone_num,
-            'intl_telephone_num': cls.intl_telephone_num
+            'intl_telephone_num': cls.intl_telephone_url
         }
 
     @classmethod

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -8,6 +8,7 @@ class Backend:
     friendly_name = "In Person"
     docs_url = None
     telephone_num = None
+    intl_telephone_num = None
 
     def save_user_meeting(self, backend_metadata: dict, assignee: User):
         return {'started': True}
@@ -18,7 +19,8 @@ class Backend:
             'name': cls.name,
             'friendly_name': cls.friendly_name,
             'docs_url': cls.docs_url,
-            'telephone_num': cls.telephone_num
+            'telephone_num': cls.telephone_num,
+            'intl_telephone_num': cls.intl_telephone_num
         }
 
     @classmethod

--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -73,8 +73,9 @@ class ZoomAccessToken(TypedDict):
 class Backend:
     name: str = 'zoom'
     friendly_name: str = 'Zoom'
-    docs_url: Optional[str] = settings.ZOOM_DOCS_URL
-    telephone_num: Optional[str] = settings.ZOOM_TELE_NUM
+    docs_url: str = settings.ZOOM_DOCS_URL
+    telephone_num: str = settings.ZOOM_TELE_NUM
+    intl_telephone_url: str = settings.ZOOM_INTL_URL
 
     base_url = 'https://zoom.us'
     expiry_buffer_seconds = 60
@@ -216,7 +217,8 @@ class Backend:
             'name': cls.name,
             'friendly_name': cls.friendly_name,
             'docs_url': cls.docs_url,
-            'telephone_num': cls.telephone_num
+            'telephone_num': cls.telephone_num,
+            'intl_telephone_url': cls.intl_telephone_url
         }
     
     @classmethod


### PR DESCRIPTION
This PR makes requested changes to the text and logic of the attendee-facing queue UI. It also adds an `intl_telephone_url` to backend objects served up to the frontend for use in the new `BlueJeansDialInMessage` and `ZoomDialInMessage`. The PR aims to resolve issues #233, #235, and #247.