### PR TITLE
Give Badge and Join Info even spacing in MeetingDetails cell on QueueManagerPage

### DIFF
--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -20,10 +20,10 @@ interface MeetingDetailsProps extends MeetingEditorComponentProps {
 const MeetingDetails = (props: MeetingDetailsProps) => {
     return (
         <Row>
-            <Col md={4} className='mb-1'>
+            <Col md={6} className='mb-1'>
                 <Badge variant='secondary' aria-label='Meeting Type'>{props.readableMeetingType}</Badge>
             </Col>
-            <Col md={8}>
+            <Col md={6}>
                 <Button
                     variant='link'
                     size='sm'


### PR DESCRIPTION
This PR provides a minor tweak to spacing in the meeting tables on the `QueueManagerPage`. At smaller window widths, the meeting type badge and the "Join Info" button were overlapping, particularly with "BlueJeans" and "In Person". The `md` settings used here fix the spacing, though the spacing seems like a tad too much with the "Zoom" badge. The PR aims to resolve issue #263.