### PR TITLE
Limit Meeting Actions to host assignee, only authorize start/ endpoint for assigned host (#274)

### DIFF
--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -82,39 +82,50 @@ interface UnstartedMeetingEditorProps extends MeetingEditorProps, AssigneeSelect
 function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
     const attendee = props.meeting.attendees[0];
     const attendeeString = `${attendee.first_name} ${attendee.last_name}`;
+    const assignee = props.meeting.assignee;
 
-    const readyButton = props.meeting.assignee
-        && (
-            <Button
-                variant='success'
-                size='sm'
-                onClick={() => props.onStartMeeting(props.meeting)}
-                aria-label={`${props.meeting.backend_type === 'inperson' ? 'Ready for Attendee' : 'Create Meeting with'} ${attendeeString}`}
-                disabled={props.disabled}
-            >
-                {props.meeting.backend_type === 'inperson' ? 'Ready for Attendee' : 'Create Meeting'}
-            </Button>
-        );
-    const progressWorkflow = readyButton || <span>Please Assign Host</span>;
+    const removeButton = (
+        <RemoveButton
+            onRemove={() => props.onRemoveMeeting(props.meeting)}
+            size="sm"
+            screenReaderLabel={`Remove Meeting with ${attendeeString}`}
+            disabled={props.disabled}
+        />
+    );
+
+    const meetingActions = assignee?.id === props.user.id
+        ? (
+            <>
+            <Col lg={7} className='mb-1'>
+                <Button
+                    variant='success'
+                    size='sm'
+                    onClick={() => props.onStartMeeting(props.meeting)}
+                    aria-label={`${props.meeting.backend_type === 'inperson' ? 'Ready for Attendee' : 'Create Meeting with'} ${attendeeString}`}
+                    disabled={props.disabled}
+                >
+                    {props.meeting.backend_type === 'inperson' ? 'Ready for Attendee' : 'Create Meeting'}
+                </Button>
+                {}
+            </Col>
+            <Col lg={5}>{removeButton}</Col>
+            </>
+        )
+        : assignee
+            ? <Col><span>Only the assigned host can use meeting actions.</span></Col>
+            : (
+                <>
+                <Col lg={7} className='mb-1'><span>Please assign host.</span></Col>
+                <Col lg={5}>{removeButton}</Col>
+                </>
+            );
 
     return (
         <>
         <td><UserDisplay user={attendee}/></td>
         <td><AssigneeSelector {...props} /></td>
         <td><MeetingDetails {...props} /></td>
-        <td>
-            <Row>
-                {progressWorkflow && <Col lg={7} className='mb-1'>{progressWorkflow}</Col>}
-                <Col lg={4}>
-                    <RemoveButton
-                        onRemove={() => props.onRemoveMeeting(props.meeting)}
-                        size="sm"
-                        screenReaderLabel={`Remove Meeting with ${attendeeString}`}
-                        disabled={props.disabled}
-                    />
-                </Col>
-            </Row>
-        </td>
+        <td><Row>{meetingActions}</Row></td>
         </>
     );
 }

--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -106,7 +106,6 @@ function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
                 >
                     {props.meeting.backend_type === 'inperson' ? 'Ready for Attendee' : 'Create Meeting'}
                 </Button>
-                {}
             </Col>
             <Col lg={5}>{removeButton}</Col>
             </>

--- a/src/officehours_api/permissions.py
+++ b/src/officehours_api/permissions.py
@@ -17,7 +17,7 @@ def is_attendee(user: User, meeting: Meeting):
     )
 
 
-def is_host_assignee(user: User, meeting: Meeting):
+def is_assignee(user: User, meeting: Meeting):
     return user == meeting.assignee
 
 
@@ -48,7 +48,7 @@ class IsHostOrAttendee(permissions.BasePermission):
         )
 
 
-class IsHostAssignee(permissions.BasePermission):
+class IsAssignee(permissions.BasePermission):
     '''
     Custom permission to only allow hosts assigned to a meeting
     to start the meeting.
@@ -56,5 +56,5 @@ class IsHostAssignee(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj: Meeting):
         return (
-            is_host_assignee(request.user, obj)
+            is_assignee(request.user, obj)
         )

--- a/src/officehours_api/permissions.py
+++ b/src/officehours_api/permissions.py
@@ -17,6 +17,10 @@ def is_attendee(user: User, meeting: Meeting):
     )
 
 
+def is_host_assignee(user: User, meeting: Meeting):
+    return user == meeting.assignee
+
+
 class IsHostOrReadOnly(permissions.BasePermission):
     '''
     Custom permission to only allow hosts to edit queues
@@ -41,4 +45,16 @@ class IsHostOrAttendee(permissions.BasePermission):
         return (
             is_attendee(request.user, obj)
             or (hasattr(obj, 'queue') and is_host(request.user, obj.queue))
+        )
+
+
+class IsHostAssignee(permissions.BasePermission):
+    '''
+    Custom permission to only allow hosts assigned to a meeting
+    to start the meeting.
+    '''
+
+    def has_object_permission(self, request, view, obj: Meeting):
+        return (
+            is_host_assignee(request.user, obj)
         )

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -17,7 +17,7 @@ from officehours_api.serializers import (
     QueueHostSerializer, MeetingSerializer, AttendeeSerializer,
 )
 from officehours_api.permissions import (
-    IsHostOrReadOnly, IsHostOrAttendee, is_host,
+    IsHostAssignee, IsHostOrReadOnly, IsHostOrAttendee, is_host
 )
 
 
@@ -174,8 +174,11 @@ class MeetingDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdate
 
 
 class MeetingStart(DecoupledContextMixin, LoggingMixin, APIView):
+    permission_classes = (IsAuthenticated, IsHostAssignee,)
+
     def post(self, request, pk):
         m = Meeting.objects.get(pk=pk)
+        self.check_object_permissions(request, m)
         m.start()
         m.save()
         serializer = MeetingSerializer(m)

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -17,7 +17,7 @@ from officehours_api.serializers import (
     QueueHostSerializer, MeetingSerializer, AttendeeSerializer,
 )
 from officehours_api.permissions import (
-    IsHostAssignee, IsHostOrReadOnly, IsHostOrAttendee, is_host
+    IsAssignee, IsHostOrReadOnly, IsHostOrAttendee, is_host
 )
 
 
@@ -174,7 +174,7 @@ class MeetingDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdate
 
 
 class MeetingStart(DecoupledContextMixin, LoggingMixin, APIView):
-    permission_classes = (IsAuthenticated, IsHostAssignee,)
+    permission_classes = (IsAuthenticated, IsAssignee,)
 
     def post(self, request, pk):
         m = Meeting.objects.get(pk=pk)


### PR DESCRIPTION
This PR changes the UI workflow and underlying REST API action for starting meetings so that only the individual assigned to a meeting (`Meeting.assignee`) can start/create a meeting. While the meeting remove button is hidden once a host is assigned, the meeting deletion at the REST API level is still allowed by authenticated hosts and attendees. The PR aims to resolve issue #274.