### PR TITLE
Introduce ability to phase out backends (#303)

### DIFF
--- a/src/assets/src/components/meetingType.tsx
+++ b/src/assets/src/components/meetingType.tsx
@@ -16,6 +16,8 @@ interface AllowedMeetingBackendsFormProps {
 }
 
 export function AllowedBackendsForm(props: AllowedMeetingBackendsFormProps) {
+    const enabledBackends = props.backends.filter((value) => value.enabled)
+
     const toggleAllowed = (backend_type: string) => {
         const newAllowed = new Set(props.allowed);
         if (newAllowed.has(backend_type)) {
@@ -25,7 +27,7 @@ export function AllowedBackendsForm(props: AllowedMeetingBackendsFormProps) {
         }
         props.onChange(newAllowed);
     }
-    const allowedMeetingTypeEditors = props.backends
+    const allowedMeetingTypeEditors = enabledBackends
         .map((b) =>
             <Form.Group key={b.name} controlId={b.name}>
                 <Form.Check

--- a/src/assets/src/components/meetingType.tsx
+++ b/src/assets/src/components/meetingType.tsx
@@ -16,7 +16,7 @@ interface AllowedMeetingBackendsFormProps {
 }
 
 export function AllowedBackendsForm(props: AllowedMeetingBackendsFormProps) {
-    const enabledBackends = props.backends.filter((value) => value.enabled)
+    const enabledBackends = props.backends.filter((value) => value.enabled);
 
     const toggleAllowed = (backend_type: string) => {
         const newAllowed = new Set(props.allowed);
@@ -54,14 +54,14 @@ interface BackendSelectorProps {
 }
 
 export const BackendSelector: React.FC<BackendSelectorProps> = (props) => {  
-    const options = Array.from(props.allowedBackends)
-        .map(
-            a => (
-                <option key={a} value={a}>
-                    {getBackendByName(a as EnabledBackendName, props.backends).friendly_name}
-                </option>
-            )
+    const enabledAllowedBackends = props.backends.filter(
+        (b) => b.enabled && props.allowedBackends.has(b.name)
     );
+
+    const options = enabledAllowedBackends.map(
+        (a) => <option key={a.name} value={a.name}>{a.friendly_name}</option>
+    );
+
     const handleChange = (event: React.FormEvent<HTMLSelectElement>) => {
         props.onChange(event.currentTarget.value);
     }

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -5,6 +5,7 @@ export const VideoBackendNames: EnabledBackendName[] = ['zoom', 'bluejeans'];
 export interface MeetingBackend {
     name: EnabledBackendName;
     friendly_name: string;
+    enabled: boolean;
     docs_url: string | null;
     telephone_num: string | null;
     intl_telephone_url: string | null;

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
-from typing import Literal, Set
 
 import dj_database_url
 
@@ -217,6 +216,7 @@ def skip_auth_callback_requests(record):
         return False
     return True
 
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -334,10 +334,8 @@ BLUEJEANS_DOCS_URL = os.getenv('BLUEJEANS_DOCS_URL', DOCS_BASE_URL + 'blue-jeans
 BLUEJEANS_TELE_NUM = os.getenv('BLUEJEANS_TELE_NUM', '1.312.216.0325')
 BLUEJEANS_INTL_URL = os.getenv('BLUEJEANS_INTL_URL', 'https://www.bluejeans.com/premium-numbers')
 
-IMPLEMENTED_BACKEND = Literal['inperson', 'zoom', 'bluejeans']
-IMPLEMENTED_BACKENDS: Set[IMPLEMENTED_BACKEND] = {'inperson', 'zoom', 'bluejeans'}
-ENABLED_BACKENDS: Set[str] = {'inperson'}
-DEFAULT_BACKEND: IMPLEMENTED_BACKEND = "inperson"
+ENABLED_BACKENDS = {'inperson'}
+DEFAULT_BACKEND = "inperson"
 
 BLUEJEANS_CLIENT_ID = os.getenv('BLUEJEANS_CLIENT_ID', '').strip()
 BLUEJEANS_CLIENT_SECRET = os.getenv('BLUEJEANS_CLIENT_SECRET', '').strip()

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
+from typing import Literal, Set
 
 import dj_database_url
 
@@ -333,8 +334,10 @@ BLUEJEANS_DOCS_URL = os.getenv('BLUEJEANS_DOCS_URL', DOCS_BASE_URL + 'blue-jeans
 BLUEJEANS_TELE_NUM = os.getenv('BLUEJEANS_TELE_NUM', '1.312.216.0325')
 BLUEJEANS_INTL_URL = os.getenv('BLUEJEANS_INTL_URL', 'https://www.bluejeans.com/premium-numbers')
 
-ENABLED_BACKENDS = {'inperson'}
-DEFAULT_BACKEND = "inperson"
+IMPLEMENTED_BACKEND = Literal['inperson', 'zoom', 'bluejeans']
+IMPLEMENTED_BACKENDS: Set[IMPLEMENTED_BACKEND] = {'inperson', 'zoom', 'bluejeans'}
+ENABLED_BACKENDS: Set[str] = {'inperson'}
+DEFAULT_BACKEND: IMPLEMENTED_BACKEND = "inperson"
 
 BLUEJEANS_CLIENT_ID = os.getenv('BLUEJEANS_CLIENT_ID', '').strip()
 BLUEJEANS_CLIENT_SECRET = os.getenv('BLUEJEANS_CLIENT_SECRET', '').strip()

--- a/src/officehours_api/backends/backend_dict.py
+++ b/src/officehours_api/backends/backend_dict.py
@@ -4,6 +4,7 @@ from typing import Optional, TypedDict
 class BackendDict(TypedDict):
     name: str
     friendly_name: str
+    enabled: bool
     docs_url: Optional[str]
     telephone_num: Optional[str]
     intl_telephone_url: Optional[str]

--- a/src/officehours_api/backends/backend_phaser.py
+++ b/src/officehours_api/backends/backend_phaser.py
@@ -1,8 +1,6 @@
 import logging
 from typing import List
 
-from django.conf import settings
-
 from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
 from officehours_api.models import Meeting, MeetingStatus, Queue
 
@@ -31,13 +29,13 @@ class BackendPhaser:
         Queue.objects.bulk_update(queues_allowing_backend, fields=['allowed_backends'])
         return queues_allowing_backend
 
-    def set_unstarted_meetings_to_default_backend(self) -> List[Meeting]:
+    def set_unstarted_meetings_to_other_backend(self) -> List[Meeting]:
         meetings_with_backend = self.get_meetings_with_backend()
         unstarted_meetings_with_backend: List[Meeting] = [
             meeting for meeting in meetings_with_backend if meeting.status != MeetingStatus.STARTED
         ]
         for meeting in unstarted_meetings_with_backend:
-            meeting.change_backend_type()  # Set to default
+            meeting.change_backend_type()  # Set to default backend or other enabled backend if applicable
         Meeting.objects.bulk_update(unstarted_meetings_with_backend, fields=['backend_type'])
         return unstarted_meetings_with_backend
 
@@ -50,7 +48,7 @@ class BackendPhaser:
             started_meeting.delete()
         return started_meetings_with_backend
 
-    def phase_out(self, remove_as_allowed: bool, set_unstarted_to_default: bool, delete_started: bool):
+    def phase_out(self, remove_as_allowed: bool, set_unstarted_to_other: bool, delete_started: bool):
         logger.info(f'Old backend: {self.backend_name}')
         if remove_as_allowed:
             logger.info(f'Removing {self.backend_name} from allowed_backends when present in queues...')
@@ -60,12 +58,12 @@ class BackendPhaser:
                 f'from {len(modified_queues)} queue(s).'
             )
 
-        if set_unstarted_to_default:
-            logger.info('Setting backend_type of unstarted meetings to use the default backend...')
-            modified_meetings = self.set_unstarted_meetings_to_default_backend()
+        if set_unstarted_to_other:
+            logger.info('Setting backend_type of unstarted meetings to use another backend...')
+            modified_meetings = self.set_unstarted_meetings_to_other_backend()
             logger.info(
                 f'Set the backend_type for {len(modified_meetings)} meeting(s) '
-                f'to the default {settings.DEFAULT_BACKEND}.'
+                f'to other allowed backends.'
             )
 
         if delete_started:

--- a/src/officehours_api/backends/backend_phaser.py
+++ b/src/officehours_api/backends/backend_phaser.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
 from officehours_api.models import Meeting, MeetingStatus, Queue
@@ -19,57 +19,70 @@ class BackendPhaser:
     def get_queues_allowing_backend(self) -> List[Queue]:
         return list(Queue.objects.filter(allowed_backends__contains=[self.backend_name]))
 
-    def get_meetings_with_backend(self) -> List[Meeting]:
-        return list(Meeting.objects.filter(backend_type=self.backend_name))
+    def get_meetings_with_backend_through_queues(self, queues: List[Queue]) -> List[Meeting]:
+        meetings_with_backend = []
+        for queue in queues:
+            meetings_with_backend += list(queue.meeting_set.filter(backend_type=self.backend_name))
+        return meetings_with_backend
 
-    def remove_backend_from_queue_allowed_backends(self) -> List[Queue]:
-        queues_allowing_backend = self.get_queues_allowing_backend()
+    def remove_backend_from_queue_allowed_backends(self, queues_allowing_backend: List[Queue]) -> List[Queue]:
         for queue in queues_allowing_backend:
             queue.remove_allowed_backend(self.backend_name)
-        Queue.objects.bulk_update(queues_allowing_backend, fields=['allowed_backends'])
         return queues_allowing_backend
 
-    def set_unstarted_meetings_to_other_backend(self) -> List[Meeting]:
-        meetings_with_backend = self.get_meetings_with_backend()
+    def set_unstarted_meetings_to_other_backend(self, meetings_with_backend: List[Meeting]) -> List[Meeting]:
         unstarted_meetings_with_backend: List[Meeting] = [
             meeting for meeting in meetings_with_backend if meeting.status != MeetingStatus.STARTED
         ]
         for meeting in unstarted_meetings_with_backend:
             meeting.change_backend_type()  # Set to default backend or other enabled backend if applicable
-        Meeting.objects.bulk_update(unstarted_meetings_with_backend, fields=['backend_type'])
         return unstarted_meetings_with_backend
 
-    def delete_started_meetings(self) -> List[Meeting]:
-        meetings_with_backend = self.get_meetings_with_backend()
+    def get_started_meetings_to_delete(self, meetings_with_backend: List[Meeting]) -> List[Meeting]:
         started_meetings_with_backend: List[Meeting] = [
             meeting for meeting in meetings_with_backend if meeting.status == MeetingStatus.STARTED
         ]
-        for started_meeting in started_meetings_with_backend:
-            started_meeting.delete()
         return started_meetings_with_backend
 
-    def phase_out(self, remove_as_allowed: bool, set_unstarted_to_other: bool, delete_started: bool):
+    def phase_out(self, remove_as_allowed: bool, set_unstarted_to_other: bool, delete_started: bool, dry_run: bool):
         logger.info(f'Old backend: {self.backend_name}')
+        queues_allowing_backend = self.get_queues_allowing_backend()
+        modified_queues: Optional[List[Queue]] = None
+        meetings_with_backend: List[Meeting] = self.get_meetings_with_backend_through_queues(queues_allowing_backend)
+
         if remove_as_allowed:
             logger.info(f'Removing {self.backend_name} from allowed_backends when present in queues...')
-            modified_queues = self.remove_backend_from_queue_allowed_backends()
+            modified_queues = self.remove_backend_from_queue_allowed_backends(queues_allowing_backend)
             logger.info(
                 f'Removed {self.backend_name} as an allowed backend '
                 f'from {len(modified_queues)} queue(s).'
             )
+            if not dry_run:
+                Queue.objects.bulk_update(modified_queues, fields=['allowed_backends'])
+                logger.info('Persisted allowed_backends queue changes to the database.')
 
         if set_unstarted_to_other:
             logger.info('Setting backend_type of unstarted meetings to use another backend...')
-            modified_meetings = self.set_unstarted_meetings_to_other_backend()
+            if modified_queues:
+                meetings_with_backend = self.get_meetings_with_backend_through_queues(modified_queues)
+
+            modified_meetings = self.set_unstarted_meetings_to_other_backend(meetings_with_backend)
             logger.info(
                 f'Set the backend_type for {len(modified_meetings)} meeting(s) '
                 f'to other allowed backends.'
             )
+            if not dry_run:
+                Meeting.objects.bulk_update(modified_meetings, fields=['backend_type'])
+                logger.info('Persisted backend_type changes to the database.')
 
         if delete_started:
-            logger.info(f'Deleting started meetings with {self.backend_name} as backend_type...')
-            deleted_meetings = self.delete_started_meetings()
+            logger.info(f'Finding started meetings with {self.backend_name} as backend_type...')
+            started_meetings_to_delete = self.get_started_meetings_to_delete(meetings_with_backend)
             logger.info(
-                f'Deleted {len(deleted_meetings)} '
+                f'Will delete {len(started_meetings_to_delete)} '
                 f'started meeting(s) with backend_type {self.backend_name}.'
             )
+            if not dry_run:
+                for meeting_to_delete in started_meetings_to_delete:
+                    meeting_to_delete.delete()
+                logger.info('Deleted started meeting(s) with backend_type')

--- a/src/officehours_api/backends/backend_phaser.py
+++ b/src/officehours_api/backends/backend_phaser.py
@@ -1,0 +1,67 @@
+import logging
+from typing import List
+
+from django.conf import settings
+from django.db.models import QuerySet
+
+from officehours_api.models import Meeting, MeetingStatus, Queue
+
+
+logger = logging.getLogger(__name__)
+
+
+class BackendPhaser:
+    """
+    Class for managing queries and operations related to the phasing out of backends.
+    """
+
+    def __init__(self, old_backend: settings.IMPLEMENTED_BACKEND):
+        self.old_backend: settings.IMPLEMENTED_BACKEND = old_backend
+
+    def get_queues_allowing_backend(self) -> QuerySet:
+        return Queue.objects.filter(allowed_backends__contains=[self.old_backend])
+
+    def get_meetings_with_backend(self) -> QuerySet:
+        return Meeting.objects.filter(backend_type=self.old_backend)
+
+    def remove_backend_from_queue_allowed_backends(self):
+        queues_allowing_backend = self.get_queues_allowing_backend()
+        logger.info(f'Number of queues allowing {self.old_backend}: {len(queues_allowing_backend)}')
+        for queue in queues_allowing_backend:
+            queue.remove_allowed_backend(self.old_backend)
+            logger.info(f'Removed {self.old_backend} as an allowed backend from queue {queue.id}')
+
+    def set_unstarted_meetings_to_default_backend(self):
+        logger.info('Setting backend_type of unstarted meetings to use the default backend...')
+        meetings_with_backend = self.get_meetings_with_backend()
+        unstarted_meetings_with_old_backend: List[Meeting] = [
+            meeting for meeting in meetings_with_backend if meeting.status != MeetingStatus.STARTED
+        ]
+        for meeting in unstarted_meetings_with_old_backend:
+            meeting.change_backend_type()
+        logger.info(
+            f'Set the backend_type for {len(unstarted_meetings_with_old_backend)} meeting(s) '
+            f'to the default {settings.DEFAULT_BACKEND}.'
+        )
+
+    def delete_started_meetings(self):
+        logger.info(f'Deleting started meetings with {self.old_backend} as backend_type...')
+        meetings_with_backend = self.get_meetings_with_backend()
+        started_meetings_with_old_backend: List[Meeting] = [
+            meeting for meeting in meetings_with_backend if meeting.status == MeetingStatus.STARTED
+        ]
+        for started_meeting in started_meetings_with_old_backend:
+            started_meeting.delete()
+        logger.info(
+            f'Deleted {len(started_meetings_with_old_backend)} '
+            f'started meeting(s) with backend_type {self.old_backend}.'
+        )
+
+    def phase_out(self, remove_as_allowed: bool, set_unstarted_to_default: bool, delete_started: bool):
+        logger.info(f'Old backend: {self.old_backend}')
+        if remove_as_allowed:
+            self.remove_backend_from_queue_allowed_backends()
+        if set_unstarted_to_default:
+            self.set_unstarted_meetings_to_default_backend()
+        if delete_started:
+            self.delete_started_meetings()

--- a/src/officehours_api/backends/backend_phaser.py
+++ b/src/officehours_api/backends/backend_phaser.py
@@ -3,8 +3,8 @@ from typing import List
 
 from django.conf import settings
 
-from officehours_api.models import Meeting, MeetingStatus, Queue
 from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
+from officehours_api.models import Meeting, MeetingStatus, Queue
 
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class BackendPhaser:
             meeting for meeting in meetings_with_backend if meeting.status != MeetingStatus.STARTED
         ]
         for meeting in unstarted_meetings_with_backend:
-            meeting.change_backend_type()
+            meeting.change_backend_type()  # Set to default
         Meeting.objects.bulk_update(unstarted_meetings_with_backend, fields=['backend_type'])
         return unstarted_meetings_with_backend
 
@@ -57,7 +57,7 @@ class BackendPhaser:
             modified_queues = self.remove_backend_from_queue_allowed_backends()
             logger.info(
                 f'Removed {self.backend_name} as an allowed backend '
-                f'from {len(modified_queues)} queues.'
+                f'from {len(modified_queues)} queue(s).'
             )
 
         if set_unstarted_to_default:

--- a/src/officehours_api/backends/backend_phaser.py
+++ b/src/officehours_api/backends/backend_phaser.py
@@ -2,7 +2,6 @@ import logging
 from typing import List
 
 from django.conf import settings
-from django.db.models import QuerySet
 
 from officehours_api.models import Meeting, MeetingStatus, Queue
 from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
@@ -19,18 +18,23 @@ class BackendPhaser:
     def __init__(self, old_backend_name: IMPLEMENTED_BACKEND_NAME):
         self.backend_name: IMPLEMENTED_BACKEND_NAME = old_backend_name
 
-    def get_queues_allowing_backend(self) -> QuerySet:
-        return Queue.objects.filter(allowed_backends__contains=[self.backend_name])
+    def get_queues_allowing_backend(self) -> List[Queue]:
+        return list(Queue.objects.filter(allowed_backends__contains=[self.backend_name]))
 
-    def get_meetings_with_backend(self) -> QuerySet:
-        return Meeting.objects.filter(backend_type=self.backend_name)
+    def get_meetings_with_backend(self) -> List[Meeting]:
+        return list(Meeting.objects.filter(backend_type=self.backend_name))
 
     def remove_backend_from_queue_allowed_backends(self):
+        logger.info(f'Removing {self.backend_name} from allowed_backends when present in queues...')
         queues_allowing_backend = self.get_queues_allowing_backend()
         logger.info(f'Number of queues allowing {self.backend_name}: {len(queues_allowing_backend)}')
         for queue in queues_allowing_backend:
             queue.remove_allowed_backend(self.backend_name)
-            logger.info(f'Removed {self.backend_name} as an allowed backend from queue {queue.id}')
+        Queue.objects.bulk_update(queues_allowing_backend, fields=['allowed_backends'])
+        logger.info(
+            f'Removed {self.backend_name} as an allowed backend '
+            f'from {len(queues_allowing_backend)} queues.'
+        )
 
     def set_unstarted_meetings_to_default_backend(self):
         logger.info('Setting backend_type of unstarted meetings to use the default backend...')
@@ -40,6 +44,7 @@ class BackendPhaser:
         ]
         for meeting in unstarted_meetings_with_backend:
             meeting.change_backend_type()
+        Meeting.objects.bulk_update(unstarted_meetings_with_backend, fields=['backend_type'])
         logger.info(
             f'Set the backend_type for {len(unstarted_meetings_with_backend)} meeting(s) '
             f'to the default {settings.DEFAULT_BACKEND}.'

--- a/src/officehours_api/backends/backend_phaser.py
+++ b/src/officehours_api/backends/backend_phaser.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db.models import QuerySet
 
 from officehours_api.models import Meeting, MeetingStatus, Queue
+from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
 
 
 logger = logging.getLogger(__name__)
@@ -15,50 +16,50 @@ class BackendPhaser:
     Class for managing queries and operations related to the phasing out of backends.
     """
 
-    def __init__(self, old_backend: settings.IMPLEMENTED_BACKEND):
-        self.old_backend: settings.IMPLEMENTED_BACKEND = old_backend
+    def __init__(self, old_backend_name: IMPLEMENTED_BACKEND_NAME):
+        self.backend_name: IMPLEMENTED_BACKEND_NAME = old_backend_name
 
     def get_queues_allowing_backend(self) -> QuerySet:
-        return Queue.objects.filter(allowed_backends__contains=[self.old_backend])
+        return Queue.objects.filter(allowed_backends__contains=[self.backend_name])
 
     def get_meetings_with_backend(self) -> QuerySet:
-        return Meeting.objects.filter(backend_type=self.old_backend)
+        return Meeting.objects.filter(backend_type=self.backend_name)
 
     def remove_backend_from_queue_allowed_backends(self):
         queues_allowing_backend = self.get_queues_allowing_backend()
-        logger.info(f'Number of queues allowing {self.old_backend}: {len(queues_allowing_backend)}')
+        logger.info(f'Number of queues allowing {self.backend_name}: {len(queues_allowing_backend)}')
         for queue in queues_allowing_backend:
-            queue.remove_allowed_backend(self.old_backend)
-            logger.info(f'Removed {self.old_backend} as an allowed backend from queue {queue.id}')
+            queue.remove_allowed_backend(self.backend_name)
+            logger.info(f'Removed {self.backend_name} as an allowed backend from queue {queue.id}')
 
     def set_unstarted_meetings_to_default_backend(self):
         logger.info('Setting backend_type of unstarted meetings to use the default backend...')
         meetings_with_backend = self.get_meetings_with_backend()
-        unstarted_meetings_with_old_backend: List[Meeting] = [
+        unstarted_meetings_with_backend: List[Meeting] = [
             meeting for meeting in meetings_with_backend if meeting.status != MeetingStatus.STARTED
         ]
-        for meeting in unstarted_meetings_with_old_backend:
+        for meeting in unstarted_meetings_with_backend:
             meeting.change_backend_type()
         logger.info(
-            f'Set the backend_type for {len(unstarted_meetings_with_old_backend)} meeting(s) '
+            f'Set the backend_type for {len(unstarted_meetings_with_backend)} meeting(s) '
             f'to the default {settings.DEFAULT_BACKEND}.'
         )
 
     def delete_started_meetings(self):
-        logger.info(f'Deleting started meetings with {self.old_backend} as backend_type...')
+        logger.info(f'Deleting started meetings with {self.backend_name} as backend_type...')
         meetings_with_backend = self.get_meetings_with_backend()
-        started_meetings_with_old_backend: List[Meeting] = [
+        started_meetings_with_backend: List[Meeting] = [
             meeting for meeting in meetings_with_backend if meeting.status == MeetingStatus.STARTED
         ]
-        for started_meeting in started_meetings_with_old_backend:
+        for started_meeting in started_meetings_with_backend:
             started_meeting.delete()
         logger.info(
-            f'Deleted {len(started_meetings_with_old_backend)} '
-            f'started meeting(s) with backend_type {self.old_backend}.'
+            f'Deleted {len(started_meetings_with_backend)} '
+            f'started meeting(s) with backend_type {self.backend_name}.'
         )
 
     def phase_out(self, remove_as_allowed: bool, set_unstarted_to_default: bool, delete_started: bool):
-        logger.info(f'Old backend: {self.old_backend}')
+        logger.info(f'Old backend: {self.backend_name}')
         if remove_as_allowed:
             self.remove_backend_from_queue_allowed_backends()
         if set_unstarted_to_default:

--- a/src/officehours_api/backends/bluejeans.py
+++ b/src/officehours_api/backends/bluejeans.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ValidationError
 from django.conf import settings
 from django.contrib.auth.models import User
 
-from officehours_api.backends.backend_dict import BackendDict
+from officehours_api.backends.types import BackendDict, IMPLEMENTED_BACKEND_NAME
 
 
 class BluejeansUserExtraFields(TypedDict):
@@ -129,7 +129,7 @@ class BluejeansClient:
 
 
 class Backend:
-    name: str = 'bluejeans'
+    name: IMPLEMENTED_BACKEND_NAME = 'bluejeans'
     friendly_name: str = 'BlueJeans'
     enabled: bool = name in settings.ENABLED_BACKENDS
 

--- a/src/officehours_api/backends/bluejeans.py
+++ b/src/officehours_api/backends/bluejeans.py
@@ -131,6 +131,8 @@ class BluejeansClient:
 class Backend:
     name: str = 'bluejeans'
     friendly_name: str = 'BlueJeans'
+    enabled: bool = name in settings.ENABLED_BACKENDS
+
     docs_url: str = settings.BLUEJEANS_DOCS_URL
     telephone_num: str = settings.BLUEJEANS_TELE_NUM
     intl_telephone_url: str = settings.BLUEJEANS_INTL_URL
@@ -189,11 +191,12 @@ class Backend:
         return {
             'name': cls.name,
             'friendly_name': cls.friendly_name,
+            'enabled': cls.enabled,
             'docs_url': cls.docs_url,
             'telephone_num': cls.telephone_num,
             'intl_telephone_url': cls.intl_telephone_url
         }
-    
+
     @classmethod
     def is_authorized(cls, user: User) -> bool:
         return True

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -6,6 +6,8 @@ from officehours_api.backends.backend_dict import BackendDict
 class Backend:
     name = 'inperson'
     friendly_name = "In Person"
+    enabled = True
+
     docs_url = None
     telephone_num = None
     intl_telephone_url = None
@@ -18,6 +20,7 @@ class Backend:
         return {
             'name': cls.name,
             'friendly_name': cls.friendly_name,
+            'enabled': cls.enabled,
             'docs_url': cls.docs_url,
             'telephone_num': cls.telephone_num,
             'intl_telephone_url': cls.intl_telephone_url

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 
 from officehours_api.backends.types import BackendDict, IMPLEMENTED_BACKEND_NAME
@@ -5,8 +6,8 @@ from officehours_api.backends.types import BackendDict, IMPLEMENTED_BACKEND_NAME
 
 class Backend:
     name: IMPLEMENTED_BACKEND_NAME = 'inperson'
-    friendly_name = "In Person"
-    enabled = True
+    friendly_name = 'In Person'
+    enabled = name in settings.ENABLED_BACKENDS
 
     docs_url = None
     telephone_num = None

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -1,10 +1,10 @@
 from django.contrib.auth.models import User
 
-from officehours_api.backends.backend_dict import BackendDict
+from officehours_api.backends.types import BackendDict, IMPLEMENTED_BACKEND_NAME
 
 
 class Backend:
-    name = 'inperson'
+    name: IMPLEMENTED_BACKEND_NAME = 'inperson'
     friendly_name = "In Person"
     enabled = True
 

--- a/src/officehours_api/backends/types.py
+++ b/src/officehours_api/backends/types.py
@@ -1,8 +1,11 @@
-from typing import Optional, TypedDict
+from typing import Literal, Optional, TypedDict
+
+
+IMPLEMENTED_BACKEND_NAME = Literal['zoom', 'bluejeans', 'inperson']
 
 
 class BackendDict(TypedDict):
-    name: str
+    name: IMPLEMENTED_BACKEND_NAME
     friendly_name: str
     enabled: bool
     docs_url: Optional[str]

--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -74,6 +74,8 @@ class ZoomAccessToken(TypedDict):
 class Backend:
     name: str = 'zoom'
     friendly_name: str = 'Zoom'
+    enabled: bool = name in settings.ENABLED_BACKENDS
+
     docs_url: str = settings.ZOOM_DOCS_URL
     telephone_num: str = settings.ZOOM_TELE_NUM
     intl_telephone_url: str = settings.ZOOM_INTL_URL
@@ -228,6 +230,7 @@ class Backend:
         return {
             'name': cls.name,
             'friendly_name': cls.friendly_name,
+            'enabled': cls.enabled,
             'docs_url': cls.docs_url,
             'telephone_num': cls.telephone_num,
             'intl_telephone_url': cls.intl_telephone_url

--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -1,18 +1,15 @@
-from typing import List, Literal, Optional, TypedDict
+from typing import List, Literal, TypedDict
 from base64 import b64encode
 from time import time
 from datetime import datetime
-import json
 import logging
 
 import requests
 from django.contrib.auth.models import User
-from django.contrib.sites.models import Site
 from django.conf import settings
-from django.urls import reverse
 from django.shortcuts import redirect
 
-from officehours_api.backends.backend_dict import BackendDict
+from officehours_api.backends.types import BackendDict, IMPLEMENTED_BACKEND_NAME
 
 
 logger = logging.getLogger(__name__)
@@ -72,7 +69,7 @@ class ZoomAccessToken(TypedDict):
 
 
 class Backend:
-    name: str = 'zoom'
+    name: IMPLEMENTED_BACKEND_NAME = 'zoom'
     friendly_name: str = 'Zoom'
     enabled: bool = name in settings.ENABLED_BACKENDS
 

--- a/src/officehours_api/exceptions.py
+++ b/src/officehours_api/exceptions.py
@@ -1,11 +1,31 @@
 import logging
 
+from django.conf import settings
 from rest_framework.views import exception_handler
 from rest_framework.response import Response
 
-from .models import BackendException
 
 logger = logging.getLogger(__name__)
+
+
+class BackendException(Exception):
+    def __init__(self, backend_type):
+        self.backend_type = backend_type
+        self.message = (
+            f'An unexpected error occurred in {self.backend_type.capitalize()}. '
+            f'You can check the ITS Status page (https://status.its.umich.edu/) '
+            f'to see if there is a known issue with {self.backend_type.capitalize()}, '
+            f'or contact the ITS Service Center (https://its.umich.edu/help) for help.'
+        )
+
+
+class DisabledBackendException(Exception):
+    def __init__(self, backend_type):
+        self.backend_type = backend_type
+        self.message = (
+            f"Backend type {self.backend_type} is no longer a supported meeting type; "
+            f"the meeting cannot be started."
+        )
 
 
 def backend_error_handler(exc, context):

--- a/src/officehours_api/exceptions.py
+++ b/src/officehours_api/exceptions.py
@@ -20,11 +20,20 @@ class BackendException(Exception):
 
 
 class DisabledBackendException(Exception):
+
     def __init__(self, backend_type: IMPLEMENTED_BACKEND_NAME):
         self.backend_type = backend_type
         self.message = (
-            f"Backend type {self.backend_type} is no longer a supported meeting type; "
-            f"the meeting cannot be started."
+            f"Backend type {self.backend_type} is no longer a supported meeting type."
+        )
+
+
+class NotAllowedBackendException(Exception):
+
+    def __init__(self, backend_type: IMPLEMENTED_BACKEND_NAME):
+        self.backend_type = backend_type
+        self.message = (
+            f"Backend type {self.backend_type} is not an allowed backend for the queue."
         )
 
 

--- a/src/officehours_api/exceptions.py
+++ b/src/officehours_api/exceptions.py
@@ -1,15 +1,15 @@
 import logging
 
-from django.conf import settings
 from rest_framework.views import exception_handler
 from rest_framework.response import Response
 
+from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
 
 logger = logging.getLogger(__name__)
 
 
 class BackendException(Exception):
-    def __init__(self, backend_type):
+    def __init__(self, backend_type: IMPLEMENTED_BACKEND_NAME):
         self.backend_type = backend_type
         self.message = (
             f'An unexpected error occurred in {self.backend_type.capitalize()}. '
@@ -20,7 +20,7 @@ class BackendException(Exception):
 
 
 class DisabledBackendException(Exception):
-    def __init__(self, backend_type):
+    def __init__(self, backend_type: IMPLEMENTED_BACKEND_NAME):
         self.backend_type = backend_type
         self.message = (
             f"Backend type {self.backend_type} is no longer a supported meeting type; "

--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -3,7 +3,9 @@ from typing import Set
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from officehours_api.backends import __all__ as IMPLEMENTED_BACKEND_NAMES
 from officehours_api.backends.backend_phaser import BackendPhaser
+from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
 
 
 class Command(BaseCommand):
@@ -35,11 +37,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        old_backends: Set[settings.IMPLEMENTED_BACKEND] = settings.IMPLEMENTED_BACKENDS - settings.ENABLED_BACKENDS
-        self.stdout.write('Identified one or more old backends: ' + ', '.join(list(old_backends)))
+        old_backend_names: Set[IMPLEMENTED_BACKEND_NAME] = set(IMPLEMENTED_BACKEND_NAMES) - settings.ENABLED_BACKENDS
+        self.stdout.write('Identified one or more old backends: ' + ', '.join(list(old_backend_names)))
 
-        for old_backend in old_backends:
-            phaser = BackendPhaser(old_backend)
+        for old_backend_name in old_backend_names:
+            phaser = BackendPhaser(old_backend_name)
             phaser.phase_out(
                 options['remove_as_allowed'],
                 options['set_unstarted_to_default'],

--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -1,0 +1,62 @@
+from typing import List, Optional, Set
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db.models import QuerySet
+
+from officehours_api.models import Meeting, MeetingStatus, Queue
+
+
+class Command(BaseCommand):
+    help = (
+        'phase_out_backends identifies implemented backends that are not enabled '
+        '(i.e. that lack configuration variables) '
+        'and modifies Queue and Meeting objects that use those disabled backends.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--delete-started',
+            dest='delete-started',
+            action='store_true',
+            help='Optionally delete started meetings with disabled backends.'
+        )
+
+    def phase_out_backend(self, old_backend: settings.IMPLEMENTED_BACKEND, delete_started_meetings: bool):
+        self.stdout.write(f'Old backend: {old_backend}')
+        queues_allowing_old_backend = Queue.objects.filter(allowed_backends__contains=[old_backend])
+        self.stdout.write(f'Number of queues allowing {old_backend}: {len(queues_allowing_old_backend)}')
+        for queue in queues_allowing_old_backend:
+            queue.remove_allowed_backend(old_backend)
+            self.stdout.write(f'Removed {old_backend} as an allowed backend from queue {queue.id}')
+
+            meetings_with_old_backend: QuerySet = queue.meeting_set.filter(backend_type=old_backend)
+            unstarted_meetings_with_old_backend: List[Meeting] = [
+                meeting for meeting in meetings_with_old_backend if meeting.status != MeetingStatus.STARTED
+            ]
+            for meeting in unstarted_meetings_with_old_backend:
+                meeting.change_backend_type()  # Set to default
+            self.stdout.write(
+                f'Set the backend_type for {len(unstarted_meetings_with_old_backend)} meetings '
+                f'from queue {queue.id} to the default.'
+            )
+
+            if delete_started_meetings:
+                self.stdout.write(f'Deleting started meetings with {old_backend} as backend_type...')
+                started_meeting_with_old_backend: List[Meeting] = [
+                    meeting for meeting in meetings_with_old_backend
+                    if meeting.status == MeetingStatus.STARTED
+                ]
+                for started_meeting in started_meeting_with_old_backend:
+                    started_meeting.delete()
+                self.stdout.write(
+                    f'Deleted {len(unstarted_meetings_with_old_backend)} started meetings '
+                    f'with backend_type {old_backend} from queue {queue.id}.'
+                )
+
+    def handle(self, *args, **options):
+        old_backends: Set[settings.IMPLEMENTED_BACKEND] = settings.IMPLEMENTED_BACKENDS - settings.ENABLED_BACKENDS
+        self.stdout.write('Identified one or more old backends: ' + ', '.join(list(old_backends)))
+
+        for old_backend in old_backends:
+            self.phase_out_backend(old_backend, options.get('delete-started'))

--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -24,10 +24,10 @@ class Command(BaseCommand):
             help='Remove disabled backends as allowed backends for queues.'
         )
         parser.add_argument(
-            '--set-unstarted-to-default',
-            dest='set_unstarted_to_default',
+            '--set-unstarted-to-other',
+            dest='set_unstarted_to_other',
             action='store_true',
-            help='Change meetings using disabled backends to use the default backend type.'
+            help='Change meetings using disabled backends to use another allowed backend type.'
         )
         parser.add_argument(
             '--delete-started',
@@ -44,6 +44,6 @@ class Command(BaseCommand):
             phaser = BackendPhaser(old_backend_name)
             phaser.phase_out(
                 options['remove_as_allowed'],
-                options['set_unstarted_to_default'],
+                options['set_unstarted_to_other'],
                 options['delete_started']
             )

--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -1,62 +1,47 @@
-from typing import List, Optional, Set
+from typing import Set
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.db.models import QuerySet
 
-from officehours_api.models import Meeting, MeetingStatus, Queue
+from officehours_api.backends.backend_phaser import BackendPhaser
 
 
 class Command(BaseCommand):
     help = (
         'phase_out_backends identifies implemented backends that are not enabled '
         '(i.e. that lack configuration variables) '
-        'and modifies Queue and Meeting objects that use those disabled backends.'
+        'and modifies Queue and Meeting objects that use those disabled backends'
+        'according to the options passed as flags.'
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--delete-started',
-            dest='delete-started',
+            '--remove-as-allowed',
+            dest='remove_as_allowed',
             action='store_true',
-            help='Optionally delete started meetings with disabled backends.'
+            help='Remove disabled backends as allowed backends for queues.'
         )
-
-    def phase_out_backend(self, old_backend: settings.IMPLEMENTED_BACKEND, delete_started_meetings: bool):
-        self.stdout.write(f'Old backend: {old_backend}')
-        queues_allowing_old_backend = Queue.objects.filter(allowed_backends__contains=[old_backend])
-        self.stdout.write(f'Number of queues allowing {old_backend}: {len(queues_allowing_old_backend)}')
-        for queue in queues_allowing_old_backend:
-            queue.remove_allowed_backend(old_backend)
-            self.stdout.write(f'Removed {old_backend} as an allowed backend from queue {queue.id}')
-
-            meetings_with_old_backend: QuerySet = queue.meeting_set.filter(backend_type=old_backend)
-            unstarted_meetings_with_old_backend: List[Meeting] = [
-                meeting for meeting in meetings_with_old_backend if meeting.status != MeetingStatus.STARTED
-            ]
-            for meeting in unstarted_meetings_with_old_backend:
-                meeting.change_backend_type()  # Set to default
-            self.stdout.write(
-                f'Set the backend_type for {len(unstarted_meetings_with_old_backend)} meetings '
-                f'from queue {queue.id} to the default.'
-            )
-
-            if delete_started_meetings:
-                self.stdout.write(f'Deleting started meetings with {old_backend} as backend_type...')
-                started_meeting_with_old_backend: List[Meeting] = [
-                    meeting for meeting in meetings_with_old_backend
-                    if meeting.status == MeetingStatus.STARTED
-                ]
-                for started_meeting in started_meeting_with_old_backend:
-                    started_meeting.delete()
-                self.stdout.write(
-                    f'Deleted {len(unstarted_meetings_with_old_backend)} started meetings '
-                    f'with backend_type {old_backend} from queue {queue.id}.'
-                )
+        parser.add_argument(
+            '--set-unstarted-to-default',
+            dest='set_unstarted_to_default',
+            action='store_true',
+            help='Change meetings using disabled backends to use the default backend type.'
+        )
+        parser.add_argument(
+            '--delete-started',
+            dest='delete_started',
+            action='store_true',
+            help='Delete started meetings with disabled backends.'
+        )
 
     def handle(self, *args, **options):
         old_backends: Set[settings.IMPLEMENTED_BACKEND] = settings.IMPLEMENTED_BACKENDS - settings.ENABLED_BACKENDS
         self.stdout.write('Identified one or more old backends: ' + ', '.join(list(old_backends)))
 
         for old_backend in old_backends:
-            self.phase_out_backend(old_backend, options.get('delete-started'))
+            phaser = BackendPhaser(old_backend)
+            phaser.phase_out(
+                options['remove_as_allowed'],
+                options['set_unstarted_to_default'],
+                options['delete_started']
+            )

--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             dest='remove_as_allowed_and_replace_unstarted',
             action='store_true',
             help=(
-                'Remove disabled backends as allowed backends for queues'
+                'Remove disabled backends as allowed backends for queues '
                 'and change meetings using disabled backends to use another allowed backend type.'
             )
         )
@@ -40,11 +40,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        old_backend_names: Set[IMPLEMENTED_BACKEND_NAME] = set(IMPLEMENTED_BACKEND_NAMES) - settings.ENABLED_BACKENDS
-        self.stdout.write('Identified one or more old backends: ' + ', '.join(list(old_backend_names)))
+        disabled_backend_names: Set[IMPLEMENTED_BACKEND_NAME] = set(IMPLEMENTED_BACKEND_NAMES) - settings.ENABLED_BACKENDS
+        self.stdout.write('Identified one or more disabled backends: ' + ', '.join(list(disabled_backend_names)))
 
-        for old_backend_name in old_backend_names:
-            phaser = BackendPhaser(old_backend_name)
+        for disabled_backend_name in disabled_backend_names:
+            phaser = BackendPhaser(disabled_backend_name)
             phaser.phase_out(
                 options['remove_as_allowed_and_replace_unstarted'],
                 options['delete_started'],

--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -18,16 +18,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--remove-as-allowed',
-            dest='remove_as_allowed',
+            '--remove-as-allowed-and-replace-unstarted',
+            dest='remove_as_allowed_and_replace_unstarted',
             action='store_true',
-            help='Remove disabled backends as allowed backends for queues.'
-        )
-        parser.add_argument(
-            '--set-unstarted-to-other',
-            dest='set_unstarted_to_other',
-            action='store_true',
-            help='Change meetings using disabled backends to use another allowed backend type.'
+            help=(
+                'Remove disabled backends as allowed backends for queues'
+                'and change meetings using disabled backends to use another allowed backend type.'
+            )
         )
         parser.add_argument(
             '--delete-started',
@@ -49,8 +46,7 @@ class Command(BaseCommand):
         for old_backend_name in old_backend_names:
             phaser = BackendPhaser(old_backend_name)
             phaser.phase_out(
-                options['remove_as_allowed'],
-                options['set_unstarted_to_other'],
+                options['remove_as_allowed_and_replace_unstarted'],
                 options['delete_started'],
                 options['dry_run']
             )

--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -35,6 +35,12 @@ class Command(BaseCommand):
             action='store_true',
             help='Delete started meetings with disabled backends.'
         )
+        parser.add_argument(
+            '--dry-run',
+            dest='dry_run',
+            action='store_true',
+            help='Do not save changes made (helps to assess impact of operations).'
+        )
 
     def handle(self, *args, **options):
         old_backend_names: Set[IMPLEMENTED_BACKEND_NAME] = set(IMPLEMENTED_BACKEND_NAMES) - settings.ENABLED_BACKENDS
@@ -45,5 +51,6 @@ class Command(BaseCommand):
             phaser.phase_out(
                 options['remove_as_allowed'],
                 options['set_unstarted_to_other'],
-                options['delete_started']
+                options['delete_started'],
+                options['dry_run']
             )

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -92,7 +92,7 @@ class Queue(SafeDeleteModel):
     def hosts_with_phone_numbers(self):
         return get_users_with_emails(self.hosts)
 
-    def remove_allowed_backend(self, old_backend: str):
+    def remove_allowed_backend(self, old_backend: settings.IMPLEMENTED_BACKEND):
         new_allowed_backends = list(filter(lambda x: x != old_backend, self.allowed_backends))
         if len(new_allowed_backends) == 0:
             new_allowed_backends.append(get_default_backend())
@@ -135,7 +135,7 @@ class Meeting(SafeDeleteModel):
     def attendees_with_phone_numbers(self):
         return get_users_with_emails(self.attendees)
 
-    def change_backend_type(self, new_backend: Optional[str] = None):
+    def change_backend_type(self, new_backend: Optional[settings.IMPLEMENTED_BACKEND] = None):
         self.backend_type = new_backend if new_backend else get_default_backend()
         self.save()
 

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -98,7 +98,6 @@ class Queue(SafeDeleteModel):
         if len(new_allowed_backends) == 0:
             new_allowed_backends.append(get_default_backend())
         self.allowed_backends = new_allowed_backends
-        self.save()
 
     def __str__(self):
         return self.name
@@ -138,7 +137,6 @@ class Meeting(SafeDeleteModel):
 
     def change_backend_type(self, new_backend_name: Optional[IMPLEMENTED_BACKEND_NAME] = None):
         self.backend_type = new_backend_name if new_backend_name else get_default_backend()
-        self.save()
 
     def __init__(self, *args, **kwargs):
         super(Meeting, self).__init__(*args, **kwargs)

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -16,6 +16,7 @@ from requests.exceptions import RequestException
 
 from officehours_api.exceptions import BackendException, DisabledBackendException
 from officehours_api import backends
+from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
 
 BACKEND_INSTANCES = {
     backend_name: getattr(getattr(backends, backend_name), 'Backend')()
@@ -92,8 +93,8 @@ class Queue(SafeDeleteModel):
     def hosts_with_phone_numbers(self):
         return get_users_with_emails(self.hosts)
 
-    def remove_allowed_backend(self, old_backend: settings.IMPLEMENTED_BACKEND):
-        new_allowed_backends = list(filter(lambda x: x != old_backend, self.allowed_backends))
+    def remove_allowed_backend(self, backend_name: IMPLEMENTED_BACKEND_NAME):
+        new_allowed_backends = list(filter(lambda x: x != backend_name, self.allowed_backends))
         if len(new_allowed_backends) == 0:
             new_allowed_backends.append(get_default_backend())
         self.allowed_backends = new_allowed_backends
@@ -135,8 +136,8 @@ class Meeting(SafeDeleteModel):
     def attendees_with_phone_numbers(self):
         return get_users_with_emails(self.attendees)
 
-    def change_backend_type(self, new_backend: Optional[settings.IMPLEMENTED_BACKEND] = None):
-        self.backend_type = new_backend if new_backend else get_default_backend()
+    def change_backend_type(self, new_backend_name: Optional[IMPLEMENTED_BACKEND_NAME] = None):
+        self.backend_type = new_backend_name if new_backend_name else get_default_backend()
         self.save()
 
     def __init__(self, *args, **kwargs):

--- a/src/officehours_ui/context_processors.py
+++ b/src/officehours_ui/context_processors.py
@@ -1,9 +1,10 @@
-from typing import List, TypedDict, Union
+from typing import List
 
 from django.conf import settings
 
 from officehours_api import backends
-from officehours_api.backends.backend_dict import BackendDict
+from officehours_api.backends import __all__ as IMPLEMENTED_BACKEND_NAMES
+from officehours_api.backends.types import BackendDict
 
 
 def feedback(request):
@@ -28,7 +29,7 @@ def spa_globals(request):
 
     backend_dicts: List[BackendDict] = [
         getattr(getattr(backends, backend_name), 'Backend').get_public_data()
-        for backend_name in settings.IMPLEMENTED_BACKENDS
+        for backend_name in IMPLEMENTED_BACKEND_NAMES
     ]
 
     return {

--- a/src/officehours_ui/context_processors.py
+++ b/src/officehours_ui/context_processors.py
@@ -28,7 +28,7 @@ def spa_globals(request):
 
     backend_dicts: List[BackendDict] = [
         getattr(getattr(backends, backend_name), 'Backend').get_public_data()
-        for backend_name in settings.ENABLED_BACKENDS
+        for backend_name in settings.IMPLEMENTED_BACKENDS
     ]
 
     return {

--- a/src/officehours_ui/views.py
+++ b/src/officehours_ui/views.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from django.urls import reverse
 
 from officehours_api import backends
+from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
 
 BACKEND_CLASSES = {
     backend_name: getattr(getattr(backends, backend_name), 'Backend')
@@ -36,7 +37,7 @@ class AuthPromptView(TemplateView):
         return context
 
 
-def auth_callback_view(request, backend_name: str):
+def auth_callback_view(request, backend_name: IMPLEMENTED_BACKEND_NAME):
     try:
         auth_callback = BACKEND_CLASSES[backend_name].auth_callback
     except KeyError:


### PR DESCRIPTION
This PR makes modifications to backends and introduces a new `BackendPhaser` class in order to allow the application to more seamlessly phase out backends that are being retired. The modifications include:

* the addition of an `enabled` class variable to each implemented backend and the passing of all backend metadata via `context_processors.py` (as opposed to just metadata for the enabled ones, as previously);
* the use of the `enabled` property on `MeetingBackend` within the `meetingType` module to hide disabled backends as options in the UI
* a new class called `BackendPhaser`, which collects database operations needed to clear a backend name from queues and meetings
* a couple new model methods to facilitate the operations in `BackendPhaser`
* a Django management command `phase_out_backends` which makes use of `BackendPhaser`
* and other miscellaneous edits and exception handling to minimize the disruption of disabling a backend.

The PR aims to resolve issue #303.