### PR TITLE
Remove mention of BlueJeans from login page

### DIFF
--- a/src/assets/src/components/home.tsx
+++ b/src/assets/src/components/home.tsx
@@ -53,9 +53,7 @@ export function HomePage(props: PageProps) {
         )
         : (
             <>
-            <p className="lead">
-                Join or host a queue for office hours over BlueJeans!
-            </p>
+            <p className="lead">Join or host a queue for office hours!</p>
             <a href={props.loginUrl} className="btn btn-primary btn-lg">Login</a>
             </>
         );


### PR DESCRIPTION
This PR changes the text presented to the user before they have logged in, as requested by @mfldavidson, so that it does not mention backend or meeting types implemented. The PR aims to resolve issue #304.