### PR TITLE
Give host info about host key for dial in (#301)

### DIFF
--- a/src/assets/src/components/dialIn.tsx
+++ b/src/assets/src/components/dialIn.tsx
@@ -25,7 +25,10 @@ const IntlTelephoneLink = (props: IntlTelephoneLinkProps) => {
     );
 }
 
-type DialInMessageProps = OneTouchDialLinkProps & IntlTelephoneLinkProps;
+interface DialInMessageProps extends OneTouchDialLinkProps, IntlTelephoneLinkProps {
+    isHost?: boolean;
+    profileURL?: string;
+}
 
 const BlueJeansDialInMessage = (props: DialInMessageProps) => {
     const phoneLinkUsa = <OneTouchDialLink {...props} />;
@@ -41,19 +44,31 @@ const BlueJeansDialInMessage = (props: DialInMessageProps) => {
 
 const ZoomDialInMessage = (props: DialInMessageProps) => {
     const phoneLinkUsa = <OneTouchDialLink {...props} />;
+
+    const hostMessage = (props.isHost && props.profileURL) && (
+        <p>
+            When calling in by phone, you will need to enter a host key to start the meeting.
+            Find your host key at the bottom of <a href={props.profileURL}>your Zoom profile</a>.
+            DO NOT share your host key with anyone!
+        </p>
+    )
+
     return (
-        <span>
+        <>
+        <p>
             Having problems with video? As a back-up, you can call {phoneLinkUsa} from the USA
             (or <IntlTelephoneLink {...props} /> -- click See All Numbers under Toll Call to see all countries)
-            from any phone and enter {props.meetingNumber}#.
-            You do not need a host key or participant ID.
-        </span>
+            from any phone and enter {props.meetingNumber}#. You do not need a participant ID.
+        </p>
+        {hostMessage}
+        </>
     );
 }
 
 interface DialInContentProps {
     metadata: BluejeansMetadata | ZoomMetadata;
     backend: MeetingBackend;
+    isHost?: boolean;
 }
 
 export const DialInContent = (props: DialInContentProps) => {
@@ -62,7 +77,9 @@ export const DialInContent = (props: DialInContentProps) => {
         const dialInProps = {
             phone: props.backend.telephone_num,
             meetingNumber: props.metadata.numeric_meeting_id,
-            intlNumbersURL: props.backend.intl_telephone_url
+            intlNumbersURL: props.backend.intl_telephone_url,
+            isHost: props.isHost,
+            profileURL: props.backend.profile_url
         } as DialInMessageProps;
 
         dialInMessage = props.backend.name === 'zoom'

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -224,7 +224,7 @@ const MeetingInfoDialog = (props: MeetingInfoDialogProps) => {
             ? (
                 <>
                 <p>This meeting will be via <strong>{meetingBackend.friendly_name}</strong>.</p>
-                <DialInContent metadata={props.meeting.backend_metadata} backend={meetingBackend} />
+                <DialInContent metadata={props.meeting.backend_metadata} backend={meetingBackend} isHost />
                 </>
             )
             : <div><p>This meeting will be <strong>In Person</strong>.</p></div>;

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -7,7 +7,7 @@ export interface MeetingBackend {
     friendly_name: string;
     enabled: boolean;
     docs_url: string | null;
-    profile_url: string;
+    profile_url?: string;
     telephone_num: string | null;
     intl_telephone_url: string | null;
 }

--- a/src/assets/src/models.ts
+++ b/src/assets/src/models.ts
@@ -7,6 +7,7 @@ export interface MeetingBackend {
     friendly_name: string;
     enabled: boolean;
     docs_url: string | null;
+    profile_url: string;
     telephone_num: string | null;
     intl_telephone_url: string | null;
 }

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -325,9 +325,10 @@ TWILIO_MESSAGING_SERVICE_SID = os.getenv('TWILIO_MESSAGING_SERVICE_SID')
 DOCS_BASE_URL = 'https://its.umich.edu/communication/videoconferencing/'
 
 ZOOM_DOCS_URL = os.getenv('ZOOM_DOCS_URL', DOCS_BASE_URL + 'zoom/getting-started')
-ZOOM_TELE_NUM = os.getenv('ZOOM_TELE_NUM', '1.312.626.6799')
-ZOOM_INTL_URL = os.getenv('ZOOM_INTL_URL', 'https://umich.zoom.us/profile/setting?tab=telephony')
 ZOOM_BASE_DOMAIN_URL = os.getenv('ZOOM_BASE_DOMAIN_URL', 'https://umich.zoom.us')
+ZOOM_PROFILE_URL = os.getenv('ZOOM_PROFILE_URL', ZOOM_BASE_DOMAIN_URL + '/profile')
+ZOOM_INTL_URL = os.getenv('ZOOM_INTL_URL', ZOOM_PROFILE_URL + '/setting?tab=telephony')
+ZOOM_TELE_NUM = os.getenv('ZOOM_TELE_NUM', '1.312.626.6799')
 ZOOM_SIGN_IN_HELP = os.getenv('ZOOM_SIGN_IN_HELP')
 
 BLUEJEANS_DOCS_URL = os.getenv('BLUEJEANS_DOCS_URL', DOCS_BASE_URL + 'blue-jeans/getting-started')

--- a/src/officehours_api/backends/bluejeans.py
+++ b/src/officehours_api/backends/bluejeans.py
@@ -134,6 +134,7 @@ class Backend:
     enabled: bool = name in settings.ENABLED_BACKENDS
 
     docs_url: str = settings.BLUEJEANS_DOCS_URL
+    profile_url = None
     telephone_num: str = settings.BLUEJEANS_TELE_NUM
     intl_telephone_url: str = settings.BLUEJEANS_INTL_URL
 
@@ -193,6 +194,7 @@ class Backend:
             'friendly_name': cls.friendly_name,
             'enabled': cls.enabled,
             'docs_url': cls.docs_url,
+            'profile_url': cls.profile_url,
             'telephone_num': cls.telephone_num,
             'intl_telephone_url': cls.intl_telephone_url
         }

--- a/src/officehours_api/backends/inperson.py
+++ b/src/officehours_api/backends/inperson.py
@@ -10,6 +10,7 @@ class Backend:
     enabled = name in settings.ENABLED_BACKENDS
 
     docs_url = None
+    profile_url = None
     telephone_num = None
     intl_telephone_url = None
 
@@ -23,6 +24,7 @@ class Backend:
             'friendly_name': cls.friendly_name,
             'enabled': cls.enabled,
             'docs_url': cls.docs_url,
+            'profile_url': cls.profile_url,
             'telephone_num': cls.telephone_num,
             'intl_telephone_url': cls.intl_telephone_url
         }

--- a/src/officehours_api/backends/types.py
+++ b/src/officehours_api/backends/types.py
@@ -9,5 +9,6 @@ class BackendDict(TypedDict):
     friendly_name: str
     enabled: bool
     docs_url: Optional[str]
+    profile_url: Optional[str]
     telephone_num: Optional[str]
     intl_telephone_url: Optional[str]

--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -74,6 +74,7 @@ class Backend:
     enabled: bool = name in settings.ENABLED_BACKENDS
 
     docs_url: str = settings.ZOOM_DOCS_URL
+    profile_url: str = settings.ZOOM_PROFILE_URL
     telephone_num: str = settings.ZOOM_TELE_NUM
     intl_telephone_url: str = settings.ZOOM_INTL_URL
     sign_in_help: str = settings.ZOOM_SIGN_IN_HELP
@@ -229,6 +230,7 @@ class Backend:
             'friendly_name': cls.friendly_name,
             'enabled': cls.enabled,
             'docs_url': cls.docs_url,
+            'profile_url': cls.profile_url,
             'telephone_num': cls.telephone_num,
             'intl_telephone_url': cls.intl_telephone_url
         }


### PR DESCRIPTION
This PR adds a nullable `profile_url` to the backend configuration workflow and leverages it in the `dialIn` module to add information for Zoom users about how to find their host key to use when calling in by phone. The PR aims to resolve issue #301.