### PR TITLE
Use RemoveButton component instead of End Meeting button (#272)

### DIFF
--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -169,15 +169,12 @@ function StartedMeetingEditor (props: MeetingEditorProps) {
             <Row>
                 {joinLink && <Col lg={6} className='mb-1'>{joinLink}</Col>}
                 <Col lg={6}>
-                    <Button
-                        variant='danger'
-                        size='sm'
-                        onClick={() => props.onRemoveMeeting(props.meeting)}
-                        aria-label={`End Meeting with ${attendeeString}`}
+                    <RemoveButton
+                        onRemove={() => props.onRemoveMeeting(props.meeting)}
+                        size="sm"
+                        screenReaderLabel={`Remove Meeting with ${attendeeString}`}
                         disabled={props.disabled}
-                    >
-                        End Meeting
-                    </Button>
+                    />
                 </Col>
             </Row>
         </td>


### PR DESCRIPTION
This PR replaces the custom "End Meeting" button previously used to remove "in progress" meetings from the queue management page with the standard `RemoveButton` component that uses a trash icon. The PR aims to resolve issue #272.