### PR TITLE
Adjust leave queue dialog text based on meeting status (#261)

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -464,7 +464,11 @@ export function QueuePage(props: PageProps<QueuePageParams>) {
             `Are you sure you want to ${dialogParts.action}? ` +
             `By ${dialogParts.gerund}, ${dialogParts.consequences}. ` +
             'If you change your mind, you will have to re-join at the end of the line.' +
-            (queueStatus === 'closed' ? ' The queue is currently closed. You will not be able to re-join until the queue is re-opened.' : '')
+            (
+                queueStatus === 'closed'
+                    ? ' Note: The queue is currently closed. You will not be able to re-join until the queue is re-opened.'
+                    : ''
+            )
         );
         showConfirmation(dialogRef, () => doLeaveQueue(), dialogParts.title, description);
     }


### PR DESCRIPTION
This PR modifies the "Leave Queue" dialog to respond to the meeting status, as requested by @mfldavidson. I modified some of the text so the conditionals would be a bit simpler. The PR aims to resolve issue #261.