### PR TITLE
Replace disabled backend with default in Queue.allowed_backends (#317)

### DIFF
--- a/src/officehours_api/management/commands/phase_out_backends.py
+++ b/src/officehours_api/management/commands/phase_out_backends.py
@@ -18,8 +18,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--remove-as-allowed-and-replace-unstarted',
-            dest='remove_as_allowed_and_replace_unstarted',
+            '--replace-allowed-and-unstarted',
+            dest='replace_allowed_and_unstarted',
             action='store_true',
             help=(
                 'Remove disabled backends as allowed backends for queues '
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         for disabled_backend_name in disabled_backend_names:
             phaser = BackendPhaser(disabled_backend_name)
             phaser.phase_out(
-                options['remove_as_allowed_and_replace_unstarted'],
+                options['replace_allowed_and_unstarted'],
                 options['delete_started'],
                 options['dry_run']
             )

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -99,10 +99,11 @@ class Queue(SafeDeleteModel):
     def hosts_with_phone_numbers(self):
         return get_users_with_emails(self.hosts)
 
-    def remove_allowed_backend(self, backend_name: IMPLEMENTED_BACKEND_NAME):
+    def replace_allowed_backend_with_default(self, backend_name: IMPLEMENTED_BACKEND_NAME):
         new_allowed_backends = list(filter(lambda x: x != backend_name, self.allowed_backends))
-        if len(new_allowed_backends) == 0:
-            new_allowed_backends.append(get_default_backend())
+        default_backend = get_default_backend()
+        if default_backend not in new_allowed_backends:
+            new_allowed_backends.append(default_backend)
         self.allowed_backends = new_allowed_backends
 
     def __str__(self):


### PR DESCRIPTION
This PR modifies the `BackendPhaser` migration logic and the `Queue` model method referenced therein to better handle the case where a `Queue` has `['inperson', 'bluejeans']` for `allowed_backends`. The model method `replace_allowed_backend_with_default` was modified so that it 1) removes the disabled backend specified, 2) checks for the default backend in the `allowed_backends` and 3) adds it to `allowed_backends` if not present. This results in `['inperson', 'zoom']`, instead of `['inperson']` as with the old logic. Unstarted meetings will subsequently be changed to the default backend, because `Meeting.change_backend_type` prefers that when it's in `meeting.queue.allowed_backends`. The PR aims to resolve issue #317. 

`Queue.allowed_backends` cases that need to be handled (expected outcome included):
* `['inperson', 'bluejeans']` -> `['inperson', 'zoom']`
* `['bluejeans']` -> `['zoom']`
* `['inperson', 'zoom', 'bluejeans']` -> `['inperson', 'zoom']`
* `['bluejeans', 'zoom']` -> `['zoom']`