### PR TITLE
Add target="_blank" to link tag for Zoom profile (#315)

### DIFF
--- a/src/assets/src/components/dialIn.tsx
+++ b/src/assets/src/components/dialIn.tsx
@@ -48,7 +48,7 @@ const ZoomDialInMessage = (props: DialInMessageProps) => {
     const hostMessage = (props.isHost && props.profileURL) && (
         <p>
             When calling in by phone, you will need to enter a host key to start the meeting.
-            Find your host key at the bottom of <a href={props.profileURL}>your Zoom profile</a>.
+            Find your host key at the bottom of <a href={props.profileURL} target='_blank'>your Zoom profile</a>.
             DO NOT share your host key with anyone!
         </p>
     )


### PR DESCRIPTION
This PR makes a requested change to the `ZoomDialInMessage` so that the Zoom profile link opens in a new tab rather than sending users away from ROHQ. The PR aims to resolve issue #315.