### PR TITLE
Add waiting room, force auth off for Zoom meetings

### DIFF
--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -161,6 +161,8 @@ class Backend(BackendBase):
                 'timezone': 'America/Detroit',
                 "settings": {
                     "join_before_host": False,
+                    "waiting_room": True,
+                    "meeting_authentication": False,
                 },
             },
         )


### PR DESCRIPTION
Since we are requiring U-M Zoom users to have one security setting on their meetings starting May 18, I want to see if turning on a waiting room and ensuring auth is off will be an ok experience. Adding these 2 lines SHOULD mean that all meetings are always secured with a waiting room that uses the user's waiting room settings, and that auth and passcode are both off. Otherwise auth will turn on if a user has it on by default. A passcode doesn't need to be set to off because there can't be one unless we pass one in the request.

Closes #268 