### PR TITLE
Pin Twisted to <21 to fix prod startup

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -16,3 +16,4 @@ django-filter~=2.2.0
 channels~=2.4.0
 channels-redis~=2.4.2
 twilio~=6.45.4
+twisted<21

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -16,4 +16,6 @@ django-filter~=2.2.0
 channels~=2.4.0
 channels-redis~=2.4.2
 twilio~=6.45.4
+
+# Transitive dependency, pinned to fix an error. See: https://github.com/tl-its-umich-edu/remote-office-hours-queue/issues/331
 twisted<21


### PR DESCRIPTION
Fixes #331 
A better long term fix would be to switch to `poetry` instead of `pip`. Having a lockfile would prevent these types of surprises.