### PR TITLE
Update backend dependencies (#383)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - officehours-postgres-data:/var/lib/postgresql/data
 
   redis:
-    image: redis:5
+    image: redis:7
 
   webpack_watcher:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - ALLOWED_HOSTS=*
       - DEBUG=True
-      - DATABASE_URL=postgresql://admin:admin@database/postgres
+      - DATABASE_URL=postgresql://admin:admin_pw@database/admin
       - FEEDBACK_EMAIL=office-hours-devs@umich.edu
     ports:
       - 8003:8001
@@ -22,10 +22,11 @@ services:
       - webpack_watcher
 
   database:
-    image: postgres:10.4-alpine
+    image: postgres:14.4-alpine
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_DB=admin
+      - POSTGRES_PASSWORD=admin_pw
     volumes:
       - officehours-postgres-data:/var/lib/postgresql/data
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -25,8 +25,8 @@ ENV WEB_CONCURRENCY=5
 RUN apt-get update
 RUN apt-get -y install gcc libpq-dev
 RUN pip install \
-    'gunicorn~=20.0.4' \
-    'uvicorn[standard]~=0.12.2' \
+    'gunicorn==20.1.0' \
+    'uvicorn[standard]==0.20.0' \
     'psycopg2~=2.9.5'
 COPY requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,11 +23,11 @@ WORKDIR /usr/src/app
 ENV WEB_CONCURRENCY=5
 
 RUN apt-get update
-RUN apt-get -y install gcc
+RUN apt-get -y install gcc libpq-dev
 RUN pip install \
     'gunicorn~=20.0.4' \
     'uvicorn[standard]~=0.12.2' \
-    'psycopg2-binary~=2.9.5'
+    'psycopg2~=2.9.5'
 COPY requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run prod
 
 #####################################################################
 
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/src/officehours/routing.py
+++ b/src/officehours/routing.py
@@ -1,15 +1,22 @@
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+
 from django.core.asgi import get_asgi_application
 
 import officehours_api.routing
 
+
+asgi_application = get_asgi_application()
+
 application = ProtocolTypeRouter({
     # (http->django views is added by default)
-    'http': get_asgi_application(),
-    'websocket': AuthMiddlewareStack(
-        URLRouter(
-            officehours_api.routing.websocket_urlpatterns
+    'http': asgi_application,
+    'websocket': AllowedHostsOriginValidator(
+        AuthMiddlewareStack(
+            URLRouter(
+                officehours_api.routing.websocket_urlpatterns
+            )
         )
-    ),
+    )
 })

--- a/src/officehours/routing.py
+++ b/src/officehours/routing.py
@@ -1,9 +1,12 @@
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
+from django.core.asgi import get_asgi_application
+
 import officehours_api.routing
 
 application = ProtocolTypeRouter({
     # (http->django views is added by default)
+    'http': get_asgi_application(),
     'websocket': AuthMiddlewareStack(
         URLRouter(
             officehours_api.routing.websocket_urlpatterns

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -46,6 +46,7 @@ ALLOWED_HOSTS = csv_to_list(os.getenv('ALLOWED_HOSTS', None))
 
 # Add additional non-Django apps here for consistent logging behavior
 EXTRA_APPS = [
+    'daphne',
     'channels',
     'officehours_api.apps.OfficehoursApiConfig',
     'officehours_ui.apps.OfficehoursUiConfig',

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -72,7 +72,7 @@ INSTALLED_APPS = [
 
 if DEBUG:
     INSTALLED_APPS += [
-        'drf_yasg',
+        'drf_spectacular',
     ]
 
 WATCHMAN_TOKENS = os.getenv('WATCHMAN_TOKENS')
@@ -118,6 +118,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
     ),
     'EXCEPTION_HANDLER': 'officehours_api.exceptions.backend_error_handler',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema'
 }
 
 

--- a/src/officehours_api/consumers.py
+++ b/src/officehours_api/consumers.py
@@ -14,7 +14,6 @@ from officehours_api.models import Queue, Meeting, Profile
 from officehours_api.permissions import is_host
 from officehours_api.serializers import (
     QueueHostSerializer, QueueAttendeeSerializer, MyUserSerializer,
-    NestedUserSerializer
 )
 
 

--- a/src/officehours_api/routing.py
+++ b/src/officehours_api/routing.py
@@ -3,6 +3,6 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r'ws/queues/(?P<queue_id>\w+)/$', consumers.QueueConsumer),
-    re_path(r'ws/users/(?P<user_id>\w+)/$', consumers.UserConsumer),
+    re_path(r'ws/queues/(?P<queue_id>\w+)/$', consumers.QueueConsumer.as_asgi()),
+    re_path(r'ws/users/(?P<user_id>\w+)/$', consumers.UserConsumer.as_asgi()),
 ]

--- a/src/officehours_api/urls.py
+++ b/src/officehours_api/urls.py
@@ -18,19 +18,3 @@ urlpatterns = [
     path('attendees/', views.AttendeeList.as_view(), name='attendee-list'),
     path('attendees/<int:pk>/', views.AttendeeDetail.as_view(), name='attendee-detail'),
 ]
-
-if settings.DEBUG:
-    from drf_yasg.views import get_schema_view as get_yasg_view
-    from drf_yasg import openapi
-
-    yasg_view = get_yasg_view(
-        openapi.Info(
-            title='Office Hours API',
-            default_version='v1',
-        ),
-    )
-
-    urlpatterns += [
-        path('swagger', yasg_view.with_ui('swagger', cache_timeout=0), name='swagger'),
-        path('redoc', yasg_view.with_ui('redoc', cache_timeout=0), name='redoc'),
-    ]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,21 +1,19 @@
-django~=3.2.16
-djangorestframework~=3.11.0
-django-rest-swagger~=2.2.0
-drf-yasg~=1.17.0
-mozilla-django-oidc~=1.2.3
-whitenoise~=5.0.1
-dj-database-url~=0.5.0
-requests~=2.23.0
-django-watchman~=1.1.0
-django-webpack-loader~=0.6.0
-django-safedelete~=0.5.4
-jsonfield~=3.1.0
+django==3.2.18
+djangorestframework==3.14.0
+# replace with drf-spectacular?
+drf-spectacular==0.25.1
+mozilla-django-oidc==3.0.0
+whitenoise==6.3.0
+dj-database-url==1.2.0
+requests==2.28.2
+django-watchman==1.3.0
+django-webpack-loader==1.8.1
+django-safedelete==1.3.1
+jsonfield==3.1.0
 django-redirect-to-non-www~=0.1.1
-drf-api-tracking~=1.6.0
-django-filter~=22.1
-channels~=2.4.0
-channels-redis~=2.4.2
-twilio~=6.45.4
-
-# Transitive dependency, pinned to fix an error. See: https://github.com/tl-its-umich-edu/remote-office-hours-queue/issues/331
-twisted<21
+# This packages seems to be getting infrequent updates, and doesn't yet support Django 4
+drf-api-tracking==1.8.0
+django-filter==22.1
+channels==4.0.0
+channels-redis~=4.0.0
+twilio~=7.16.4

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,13 +7,14 @@ whitenoise==6.3.0
 dj-database-url==1.2.0
 requests==2.28.2
 django-watchman==1.3.0
-django-webpack-loader==1.8.1
-django-safedelete==1.3.1
+django-webpack-loader==0.6.0
+django-safedelete==1.1.2
 jsonfield==3.1.0
 django-redirect-to-non-www~=0.1.1
 # This packages seems to be getting infrequent updates, and doesn't yet support Django 4
 drf-api-tracking==1.8.0
 django-filter==22.1
 channels==4.0.0
-channels-redis~=4.0.0
+channels-redis==4.0.0
+daphne==4.0.0
 twilio~=7.16.4


### PR DESCRIPTION
This PR aims to resolve #383. It is still a draft. This will need to be rebased after #382 is merged.

To Do
- [ ] Update Python (3.10, or 3.11?)
- [ ] Update Channels
  - [x] Update `redis`
  - [x] Update channels libraries, make needed changes
  - [ ] Consider optionally installing `daphne` for OpenShift
  - [ ] Figure out event loop issue in `channels_redis` (issue 332 there)
- [ ] Replace `drf-rest-swagger` with `drf-spectacular`
  - [ ] Resolve warnings with `extend_schema`?  
- [ ] Replace `jsonfield` with `django.models.JSONField`?

Resources
- 
- 