### PR TITLE
Refactor search form and URL to use query (#398)

### DIFF
--- a/src/assets/src/components/home.tsx
+++ b/src/assets/src/components/home.tsx
@@ -9,13 +9,15 @@ import { useUserWebSocket } from "../services/sockets";
 function QueueLookup() {
     const [lookup, setLookup] = useState("");
     return (
-        <form className="form-inline row mt-3" method="get" action={"/search/" + lookup}>
+        <form className="form-inline row mt-3" method="get" action="/search/">
             <div className="input-group col-sm-12 col-md-8 col-lg-6">
-                <input type="text"
+                <input
+                    type="text"
                     required
                     aria-label="Queue name or host uniqname"
                     className="form-control"
                     placeholder="Queue name or host uniqname..."
+                    name="term"
                     value={lookup}
                     onChange={(e) => setLookup(e.target.value)}
                 />

--- a/src/assets/src/components/search.tsx
+++ b/src/assets/src/components/search.tsx
@@ -20,7 +20,7 @@ export function SearchPage(props: PageProps) {
         setSearchResults
     );
     useEffect(() => {
-        if (term) {
+        if (term !== undefined) {
             doSearch(term);
         } else {
             setSearchResults([]);

--- a/src/assets/src/components/search.tsx
+++ b/src/assets/src/components/search.tsx
@@ -13,7 +13,7 @@ export function SearchPage(props: PageProps) {
     if (!props.user) {
         redirectToLogin(props.loginUrl);
     }
-    let term = (new URLSearchParams(props.location.search)).get('term') ?? undefined;
+    const term = (new URLSearchParams(props.location.search)).get('term') ?? undefined;
     const [searchResults, setSearchResults] = useState(undefined as ReadonlyArray<QueueBase> | undefined);
     const [doSearch, searchLoading, searchError] = usePromise(
         (term: string) => apiSearchQueue(term),

--- a/src/assets/src/components/search.tsx
+++ b/src/assets/src/components/search.tsx
@@ -14,9 +14,6 @@ export function SearchPage(props: PageProps) {
         redirectToLogin(props.loginUrl);
     }
     let term = (new URLSearchParams(props.location.search)).get('term') ?? undefined;
-    if (term !== undefined) {
-        term = decodeURIComponent(term);
-    }
     const [searchResults, setSearchResults] = useState(undefined as ReadonlyArray<QueueBase> | undefined);
     const [doSearch, searchLoading, searchError] = usePromise(
         (term: string) => apiSearchQueue(term),

--- a/src/assets/src/containers/app.tsx
+++ b/src/assets/src/containers/app.tsx
@@ -33,7 +33,7 @@ function App(props: AppProps) {
             <Route path='/queue/:queue_id' exact render={p => 
                 <QueuePage {...p} user={props.globals.user} loginUrl={props.globals.login_url} backends={props.globals.backends} key={(p.match.params as any).queue_id} defaultBackend={props.globals.default_backend} />
             }/>
-            <Route path={'/search/'} exact render={p =>
+            <Route path='/search/' exact render={p =>
                 <SearchPage {...p} user={props.globals.user} loginUrl={props.globals.login_url} backends={props.globals.backends} defaultBackend={props.globals.default_backend} />
             }/>
             <Route path='/preferences' exact render={p =>

--- a/src/assets/src/containers/app.tsx
+++ b/src/assets/src/containers/app.tsx
@@ -33,7 +33,7 @@ function App(props: AppProps) {
             <Route path='/queue/:queue_id' exact render={p => 
                 <QueuePage {...p} user={props.globals.user} loginUrl={props.globals.login_url} backends={props.globals.backends} key={(p.match.params as any).queue_id} defaultBackend={props.globals.default_backend} />
             }/>
-            <Route path='/search/:term' exact render={p =>
+            <Route path={'/search/'} exact render={p =>
                 <SearchPage {...p} user={props.globals.user} loginUrl={props.globals.login_url} backends={props.globals.backends} defaultBackend={props.globals.default_backend} />
             }/>
             <Route path='/preferences' exact render={p =>

--- a/src/assets/src/services/api.ts
+++ b/src/assets/src/services/api.ts
@@ -200,7 +200,7 @@ export const updateUser = async (user_id: number, phone_number: string, notify_m
 }
 
 export const searchQueue = async (term: string) => {
-    const resp = await fetch(`/api/queues_search/?search=${term}`, { method: "GET" });
+    const resp = await fetch(`/api/queues_search/?search=${encodeURIComponent(term)}`, { method: "GET" });
     await handleErrors(resp);
     return await resp.json() as ReadonlyArray<QueueBase>;
 }

--- a/src/officehours_ui/urls.py
+++ b/src/officehours_ui/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('manage/', SpaView.as_view(), name='manage'),
     path('manage/<str:queue_id>/', SpaView.as_view(), name='edit'),
     path('manage/<str:queue_id>/settings', SpaView.as_view()),
-    path('search/<str:term>/', SpaView.as_view()),
+    path('search/', SpaView.as_view()),
     path('preferences/', SpaView.as_view(), name='preferences'),
     path('add_queue/', SpaView.as_view(), name='add_queue'),
     path('auth/<backend_name>/', AuthPromptView.as_view(), name='auth_prompt'),


### PR DESCRIPTION
This PR aims to resolve #398. It replaces the URL parameter with a query parameter, which seems to be both better fitted to the use case (search term is dynamic, not a permanent resource) and to the HTML form element which uses it by default.

Sorry, @jonespm, I had already started working on this. Hopefully you're willing to test/review this instead.

Test setup

- Create a queue with no special characters or punctuation in the name.
- Create a queue with a "/" in the name.
- Create a queue with a "#" in the name.
- Create a queue with other special characters in the name.

Test cases

From the home page:
- Click "Search Queues" without any input. A pop-up should indicate the field is required.
- Enter a fragment of the name with the "/", including the "/". Check the queues listed to ensure the right queues are present.
- Enter a fragment of the name with the "#", including the "#". Check the queues listed to ensure the right queues are present.
- Enter a fragment of the name with special characters. Check the queues listed to ensure the right queues are present.

In the URL bar:
- Navigate to "https://localhost:8003/search/". Note that no results are returned and the search term is an empty string (`undefined`).
- Navigate to "https://localhost:8003/search/?term={something}" where {something} is an encoded search term. Check the queues listed to ensure the right queues are present.

Resource(s)
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form