### PR TITLE
Fixed issue #306: Enforce Meeting.backend_type in Meeting.queue.allowed_backends via API

### DIFF
--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -260,7 +260,8 @@ class MeetingSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         '''
-        Ensure the assignee is a host.
+        Ensure the assignee is a host,
+        and the meeting's backend type is in the queue's allowed backend type.
         '''
         queue = self.instance.queue if self.instance else attrs["queue"]
         hosts = queue.hosts.all()

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -268,5 +268,5 @@ class MeetingSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Assignee must be a host!")
         backend_type = attrs["backend_type"]
         if backend_type not in queue.allowed_backends:
-            raise serializers.ValidationError("Invalid backend type!")
+            raise serializers.ValidationError(f"{backend_type} is not one of the queue's allowed backend types ({queue.allowed_backends})")
         return attrs

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -266,4 +266,7 @@ class MeetingSerializer(serializers.ModelSerializer):
         hosts = queue.hosts.all()
         if attrs.get("assignee") and attrs["assignee"] not in hosts:
             raise serializers.ValidationError("Assignee must be a host!")
+        backend_type = attrs["backend_type"]
+        if backend_type not in queue.allowed_backends:
+            raise serializers.ValidationError("Invalid backend type!")
         return attrs

--- a/src/officehours_api/serializers.py
+++ b/src/officehours_api/serializers.py
@@ -267,7 +267,6 @@ class MeetingSerializer(serializers.ModelSerializer):
         hosts = queue.hosts.all()
         if attrs.get("assignee") and attrs["assignee"] not in hosts:
             raise serializers.ValidationError("Assignee must be a host!")
-        backend_type = attrs["backend_type"]
-        if backend_type not in queue.allowed_backends:
-            raise serializers.ValidationError(f"{backend_type} is not one of the queue's allowed backend types ({queue.allowed_backends})")
+        if attrs.get("backend_type") and attrs["backend_type"] not in queue.allowed_backends:
+            raise serializers.ValidationError(f"{attrs['backend_type']} is not one of the queue's allowed backend types ({queue.allowed_backends})")
         return attrs

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -169,7 +169,7 @@ class NotificationTestCase(TestCase):
 
 class MeetingSerializerTestCase(TestCase):
     """
-    Test the scenarios where the backend type is invalid, valid,
+    Test the scenarios where the backend type is invalid, is valid,
     is not updated but something else is, and is updated to be invalid.
     """
 

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -170,7 +170,7 @@ class NotificationTestCase(TestCase):
 class MeetingSerializerTestCase(TestCase):
     """
     Test the scenarios where the backend type is invalid, valid,
-    patched to none, and patched to invalid.
+    is not updated but something else is, and is updated to be invalid.
     """
 
     def setUp(self):

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -210,13 +210,14 @@ class MeetingSerializerTestCase(TestCase):
     def test_patch_backend_type_none(self):
         meeting = Meeting(**{
             'queue': self.inperson_queue,
+            'attendee': self.user2,
             'agenda': 'test agenda',
-            'assignee_id': self.user1.id,
+            'assignee': self.user1,
             'backend_type': 'inperson'
         })
         # Patch the meeting without a backend type
         data = {
-            'attendee_ids': [self.user2.id],
+            'agenda': 'patch the meeting without a backend type',
         }
         serializer = MeetingSerializer(meeting, data=data, partial=True)
         valid = serializer.is_valid(raise_exception=False)
@@ -226,13 +227,13 @@ class MeetingSerializerTestCase(TestCase):
     def test_patch_backend_type_invalid(self):
         meeting = Meeting(**{
             'queue': self.inperson_queue,
+            'attendee': self.user2,
             'agenda': 'test agenda',
-            'assignee_id': self.user1.id,
+            'assignee': self.user1,
             'backend_type': 'inperson'
         })
         # Patch the meeting to an invalid backend type
         data = {
-            'attendee_ids': [self.user2.id],
             'backend_type': 'zoom'
         }
         serializer = MeetingSerializer(meeting, data=data, partial=True)

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -1,15 +1,11 @@
 from unittest import mock, skipIf
 
 from django.test import TestCase, override_settings
-
+from rest_framework.exceptions import ValidationError
 from twilio.base.exceptions import TwilioRestException
 
-from rest_framework.exceptions import ValidationError
-
 from officehours.settings import ENABLED_BACKENDS
-
 from officehours_api.models import User, Queue, Meeting
-
 from officehours_api.serializers import MeetingSerializer
 
 

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -66,7 +66,7 @@ class NotificationTestCase(TestCase):
                 self.exceptions += 1
                 raise TwilioRestException(500, '')
         mock_twilio.messages.create.side_effect = side_effect
-    
+
     def assert_twilio_exception_logged(self, do):
         with self.assertLogs(logger='officehours_api.notifications', level='ERROR') as cm:
             do()
@@ -82,7 +82,7 @@ class NotificationTestCase(TestCase):
             receivers >=
             {'+15555551111','+15555552222',}
         )
-    
+
     @mock.patch('officehours_api.notifications.twilio')
     def test_first_meeting_bad_phone_logs_exception(self, mock_twilio: mock.MagicMock):
         self.queue.hosts.set([self.hostie, self.hostbad, self.hostacular, self.hostoptout])
@@ -210,11 +210,13 @@ class MeetingSerializerTestCase(TestCase):
     def test_patch_backend_type_none(self):
         meeting = Meeting(**{
             'queue': self.inperson_queue,
-            'attendee': self.user2,
             'agenda': 'test agenda',
             'assignee': self.user1,
             'backend_type': 'inperson'
         })
+        meeting.save()
+        meeting.attendees.add(self.user2)
+        meeting.save()
         # Patch the meeting without a backend type
         data = {
             'agenda': 'patch the meeting without a backend type',
@@ -227,11 +229,13 @@ class MeetingSerializerTestCase(TestCase):
     def test_patch_backend_type_invalid(self):
         meeting = Meeting(**{
             'queue': self.inperson_queue,
-            'attendee': self.user2,
             'agenda': 'test agenda',
             'assignee': self.user1,
             'backend_type': 'inperson'
         })
+        meeting.save()
+        meeting.attendees.add(self.user2)
+        meeting.save()
         # Patch the meeting to an invalid backend type
         data = {
             'backend_type': 'zoom'

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -207,7 +207,7 @@ class MeetingSerializerTestCase(TestCase):
         valid = serializer.is_valid(raise_exception=False)
         self.assertTrue(valid)
 
-    def test_patch_backend_type_none(self):
+    def test_patch_without_backend_type(self):
         meeting = Meeting(**{
             'queue': self.inperson_queue,
             'agenda': 'test agenda',

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -187,7 +187,7 @@ class MeetingSerializerTestCase(TestCase):
         with self.assertRaises(ValidationError) as cm:
             serializer.is_valid(raise_exception=True)
         error = str(cm.exception.detail['non_field_errors'][0])
-        self.assertEqual(error, 'Invalid backend type!')
+        self.assertEqual(error, "inperson is not one of the queue's allowed backend types (['zoom'])")
     
     def test_backend_type_valid(self):
         queue = Queue.objects.create(name='test queue', status='open', allowed_backends=['inperson'])

--- a/src/officehours_api/tests.py
+++ b/src/officehours_api/tests.py
@@ -208,48 +208,34 @@ class MeetingSerializerTestCase(TestCase):
         self.assertTrue(valid)
 
     def test_patch_backend_type_none(self):
-        data = {
-            'queue': self.inperson_queue.id,
-            'attendee_ids': [self.user2.id],
+        meeting = Meeting(**{
+            'queue': self.inperson_queue,
             'agenda': 'test agenda',
             'assignee_id': self.user1.id,
             'backend_type': 'inperson'
-        }
-        serializer = MeetingSerializer(data=data)
-        valid = serializer.is_valid(raise_exception=False)
-        self.assertTrue(valid)
+        })
         # Patch the meeting without a backend type
         data = {
-            'queue': self.inperson_queue.id,
             'attendee_ids': [self.user2.id],
-            'agenda': 'test agenda',
-            'assignee_id': self.user1.id,
         }
-        serializer = MeetingSerializer(data=data)
+        serializer = MeetingSerializer(meeting, data=data, partial=True)
         valid = serializer.is_valid(raise_exception=False)
         self.assertTrue(valid)
 
     @skipIf('zoom' not in ENABLED_BACKENDS, 'Skipping because "zoom" backend type is not enabled')
     def test_patch_backend_type_invalid(self):
-        data = {
-            'queue': self.inperson_queue.id,
-            'attendee_ids': [self.user2.id],
+        meeting = Meeting(**{
+            'queue': self.inperson_queue,
             'agenda': 'test agenda',
             'assignee_id': self.user1.id,
             'backend_type': 'inperson'
-        }
-        serializer = MeetingSerializer(data=data)
-        valid = serializer.is_valid(raise_exception=False)
-        self.assertTrue(valid)
+        })
         # Patch the meeting to an invalid backend type
         data = {
-            'queue': self.inperson_queue.id,
             'attendee_ids': [self.user2.id],
-            'agenda': 'test agenda',
-            'assignee_id': self.user1.id,
             'backend_type': 'zoom'
         }
-        serializer = MeetingSerializer(data=data)
+        serializer = MeetingSerializer(meeting, data=data, partial=True)
         with self.assertRaises(ValidationError) as cm:
             serializer.is_valid(raise_exception=True)
         error = str(cm.exception.detail['non_field_errors'][0])


### PR DESCRIPTION
Added conditions to `validate()` in `MeetingSerializer`, checking if the `backend_type` of this meeting is in the `allowed_backends` of this queue. Additionally, added unit tests to test the validation logic in `MeetingSerializerTestCase`.

This change ensures that the backend type of a meeting is only allowed if it matches the allowed backends specified for the queue. This prevents incorrect backend types from being associated with meetings and causing issues downstream.

Please review and merge this pull request if it meets the project's standards.

