### PR TITLE
Update Google Analytics library and usage (#392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ and provide for API testing using Swagger.
 The Swagger UI can be accessed by navigating to [`api/schema/swagger-ui`](http://localhost:8003/api/schema/swagger-ui).
 Once on the page, requests can be made against the API using the "Try it out" functionality.
 The OpenAPI schema can be downloaded as a YAML file from [`/api/schema`](http://localhost:8003/api/schema).
+
+### Google Analytics
+
+This application is capable of being configured to use Google Analytics 4.
+In order to send events, the environment variable `GA_TRACKING_ID` needs to be set to
+your application's [measurement ID](https://support.google.com/analytics/answer/9539598#find-G-ID)
+and the `DEBUG` environment variable and Django setting need to be off or `False`.
+Thus, a deployment environment is currently the simplest place for testing.

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import * as ReactGA from "react-ga";
+import ReactGA from "react-ga4";
 import { Alert, Button, Card, Col, Modal, Row } from "react-bootstrap";
 
 import {

--- a/src/assets/src/hooks/useGoogleAnalytics.ts
+++ b/src/assets/src/hooks/useGoogleAnalytics.ts
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
 import GoogleAnalytics from 'react-ga4';
+import { useLocation } from 'react-router-dom';
 
 export const useGoogleAnalytics = (googleAnalyticsId?: string, debug?: boolean) => {
+    let location = useLocation();
     const [initialized, setInitialized] = useState(false);
     const [previousPage, setPreviousPage] = useState(null as string | null);
 
@@ -11,10 +13,10 @@ export const useGoogleAnalytics = (googleAnalyticsId?: string, debug?: boolean) 
     }
 
     useEffect(() => {
-        const page = window.location.pathname + window.location.search + window.location.hash
+        const page = location.pathname + location.search + location.hash;
         if (googleAnalyticsId && page !== previousPage) {
             setPreviousPage(page);
             GoogleAnalytics.send({ hitType: "pageview", page });
         }
-    });
+    }, [location]);
 }

--- a/src/assets/src/hooks/useGoogleAnalytics.ts
+++ b/src/assets/src/hooks/useGoogleAnalytics.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import GoogleAnalytics from 'react-ga'
+import { useState, useEffect } from 'react';
+import GoogleAnalytics from 'react-ga4';
 
 export const useGoogleAnalytics = (googleAnalyticsId?: string, debug?: boolean) => {
     const [initialized, setInitialized] = useState(false);
@@ -7,14 +7,14 @@ export const useGoogleAnalytics = (googleAnalyticsId?: string, debug?: boolean) 
 
     if (googleAnalyticsId && !initialized) {
         setInitialized(true);
-        GoogleAnalytics.initialize(googleAnalyticsId, { debug });
+        GoogleAnalytics.initialize(googleAnalyticsId, { testMode: debug });
     }
 
     useEffect(() => {
         const page = window.location.pathname + window.location.search + window.location.hash
         if (googleAnalyticsId && page !== previousPage) {
             setPreviousPage(page);
-            GoogleAnalytics.pageview(page);
+            GoogleAnalytics.send({ hitType: "pageview", page });
         }
     });
 }

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -1,4 +1,4 @@
-import * as ReactGA from "react-ga";
+import ReactGA from "react-ga4";
 import { MyUser, QueueFull, QueueHost } from "./models";
 import * as api from "./services/api";
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.4",
         "react-dom": "^18.2.0",
-        "react-ga": "~3.3.1",
+        "react-ga4": "2.1.0",
         "react-phone-input-2": "^2.15.1",
         "react-router-dom": "^6.11.2",
         "reconnecting-websocket": "^4.4.0",
@@ -2700,14 +2700,10 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
-      }
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,7 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.4",
     "react-dom": "^18.2.0",
-    "react-ga": "~3.3.1",
+    "react-ga4": "2.1.0",
     "react-phone-input-2": "^2.15.1",
     "react-router-dom": "^6.11.2",
     "reconnecting-websocket": "^4.4.0",


### PR DESCRIPTION
This PR aims to resolve #392 and #414.

Testing notes:

Make sure "pageview" events are sent when the URL, even within the SPA.

To trigger custom events:

Host
- [x] Create a queue
-  [x] Add a host to a queue
- [x] Add a meeting on management page
- [x] Remove a meeting on management page
- [x] Start a meeting on management page
- [x] Close and/or open a queue from management page
- [x] Change an assignee on the management page
- [x] Remove a host from the settings page
- [x] Update the queue name, description, in-person meeting location, or meeting types from settings page
- [x] Delete a queue from settings page

Attendee
- [x] Join a queue
- [x] Leave a queue
- [x] Join a different queue when already in line in another queue