### PR TITLE
Remove alert and unused utility function (#236)

### DIFF
--- a/src/assets/src/components/search.tsx
+++ b/src/assets/src/components/search.tsx
@@ -44,18 +44,11 @@ export function SearchPage(props: PageProps) {
                 </p>
             )
             : <QueueTable queues={searchResults} />
-    const redirectAlert = location.search.includes("redirected=true") && term && !/^\d+$/.exec(term)
-        && (
-            <p className="alert alert-warning">
-                We didn't find a queue there! It's ok, we made a change that moved some queues around--it's us, not you. To help you find the queue you were looking for, we searched for any queues hosted by {term}. <a href="https://documentation.its.umich.edu/office-hours-links" target="_blank">Learn more about this search.</a>
-            </p>
-        );
     return (
         <div>
             <Breadcrumbs currentPageTitle="Search"/>
             {loadingDisplay}
             {errorDisplay}
-            {redirectAlert}
             <h1>Search Results: "{term}"</h1>
             <p className="lead">Select a queue to join.</p>
             {resultsDisplay}

--- a/src/assets/src/utils.ts
+++ b/src/assets/src/utils.ts
@@ -11,15 +11,6 @@ export const redirectToLogin = (loginUrl: string) => {
     location.href = loginUrl + '?next=' + location.pathname;
 }
 
-export const redirectToSearch = (term: string) => {
-    ReactGA.event({
-        category: "Navigation",
-        action: "Redirected to Search",
-        nonInteraction: true,
-    });
-    location.href = `/search/${term}/?redirected=true`;
-}
-
 export const redirectToBackendAuth = (backend: string) => {
     ReactGA.event({
         category: "Auth",


### PR DESCRIPTION
This PR aims to resolve #236. Note that it does not address the newly created issue #422.

Background

My understanding is that it used to be possible to access a queue associated with a uniqname via `/queue/{uniqname}/`. When this was removed, they supported old links by redirecting users to the search and conditionally showing an alert explaining. This is no longer the case and it's been long enough that it can be safely removed.

How/what to test

- [x] Removing `redirectToSearch` doesn't affect anything.
- [x] Navigated to `/search/?redirected=true&term=something` does not show an alert.