### PR TITLE
Return HTTP status code and message when trying to change a started meeting (#357)

### DIFF
--- a/src/officehours_api/exceptions.py
+++ b/src/officehours_api/exceptions.py
@@ -37,6 +37,12 @@ class NotAllowedBackendException(Exception):
         )
 
 
+class MeetingStartedException(Exception):
+
+    def __init__(self, field_name: str):
+        self.message = f"Can't change {field_name} once meeting is started!"
+
+
 def backend_error_handler(exc, context):
     if isinstance(exc, BackendException):
         # BackendException = Bad Gateway

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -14,7 +14,8 @@ from safedelete.models import (
 from requests.exceptions import RequestException
 
 from officehours_api.exceptions import (
-    BackendException, DisabledBackendException, NotAllowedBackendException
+    BackendException, DisabledBackendException, MeetingStartedException,
+    NotAllowedBackendException
 )
 from officehours_api import backends
 from officehours_api.backends.types import IMPLEMENTED_BACKEND_NAME
@@ -197,9 +198,9 @@ class Meeting(SafeDeleteModel):
     def save(self, *args, **kwargs):
         if self.saved_status.value >= MeetingStatus.STARTED.value:
             if self.backend_type != self._saved_backend_type:
-                raise Exception("Can't change backend_type once meeting is started!")
+                raise MeetingStartedException("backend_type")
             if self.assignee != self._saved_assignee:
-                raise Exception("Can't change assignee once meeting is started!")
+                raise MeetingStartedException("assignee")
         super().save(*args, **kwargs)
         self.saved_status = self.status
         self._saved_backend_type = self.backend_type

--- a/src/officehours_api/test_views.py
+++ b/src/officehours_api/test_views.py
@@ -1,4 +1,3 @@
-# started code reference from remote-office-hours-queue/src/officehours_api/tests.py
 import json
 from unittest import skipIf
 

--- a/src/officehours_api/test_views.py
+++ b/src/officehours_api/test_views.py
@@ -1,62 +1,51 @@
 # started code reference from remote-office-hours-queue/src/officehours_api/tests.py
 import json
 
-from django.contrib.auth.models import AnonymousUser, User
+from django.contrib.auth.models import User
 from django.test import Client, TestCase
-from rest_framework.test import APIRequestFactory
+from rest_framework import status
 
-from officehours_api.models import User, Queue, Meeting
-from officehours_api.views import MeetingDetail
+from officehours_api.models import Meeting, Queue
 
 
 class MeetingTestCase(TestCase):
 
     def setUp(self):
-        self.foo = User.objects.create(username='foo', email='foo@example.com')
-        self.bar = User.objects.create(username='bar', email='bar@example.com')
-        self.baz = User.objects.create(username='baz', email='baz@example.com')
-        self.baz.set_password('rohqtest')
-        self.baz.save()
-        self.hostie = User.objects.create(
-            username='hostie', email='hostie@example.com')
-        self.queue = Queue.objects.create(
-            name='MeetingTest',
+        self.attendee_one = User.objects.create(
+            username='attendeeone', email='attendeeone@example.com'
         )
-        self.queue.hosts.set([self.hostie, self.baz])
+        self.host_one = User.objects.create(
+            username='hostone', email='hostone@example.com'
+        )
+        self.host_one.set_password('rohqtest')
+        self.host_one.save()
+        self.host_two = User.objects.create(
+            username='hosttwo', email='hosttwo@example.com'
+        )
+        self.queue = Queue.objects.create(name='Test Queue')
+        self.queue.hosts.set([self.host_one, self.host_two])
         self.queue.save()
-        self.exceptions = 0
         self.client = Client()
 
-    # changed the create meeting from the one already in test.py (changes a bit)
-    def create_meeting(self, host, attendees, start=False):
-        m = Meeting.objects.create(
-            queue=self.queue,
-            backend_type='inperson',
-        )
-        m.attendees.set(attendees)
-        if start:
-            m.assignee = host
-            m.start()
-            m.save()
-        return m
+    def test_cannot_reassign_host_when_meeting_has_started(self):
+        meeting = Meeting.objects.create(queue=self.queue, backend_type='inperson')
+        meeting.attendees.set([self.attendee_one])
+        meeting.assignee = self.host_two
+        meeting.start()
+        meeting.save()
 
-    def test_error(self):
-        # meeting has been created where the host is self.hostie and attendees are self.foo and self.bar , the nature of the meeting is zoom
-        meeting_in_progress = self.create_meeting(self.hostie, [self.bar], True)
-        # put request to change the assignee of the meeting (not understandig what to send in this and how)
-        url = f'/api/meetings/{meeting_in_progress.id}/'
+        url = f'/api/meetings/{meeting.id}/'
         data = {
-            "attendee_ids": [self.bar.id],
-            "assignee_id": self.baz.id
+            "attendee_ids": [self.attendee_one.id],
+            "assignee_id": self.host_one.id
         }
-        
-        login_result = self.client.login(username='baz', password='rohqtest')
+        self.client.login(username='hostone', password='rohqtest')
         response = self.client.put(url, data, content_type='application/json')
 
-        # view response
-        print(response)
-        print(response.content)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         response_body = json.loads(response.content)
-
-        self.assertEqual(response_body['Meeting Detail'], "Can't change assignee once meeting is started!")
+        self.assertEqual(
+            response_body['Meeting Detail'],
+            "Can't change assignee once meeting is started!"
+        )

--- a/src/officehours_api/test_views.py
+++ b/src/officehours_api/test_views.py
@@ -25,16 +25,17 @@ class MeetingTestCase(TestCase):
         self.queue = Queue.objects.create(name='Test Queue')
         self.queue.hosts.set([self.host_one, self.host_two])
         self.queue.save()
+
+        self.meeting = Meeting.objects.create(queue=self.queue, backend_type='inperson')
+        self.meeting.attendees.set([self.attendee_one])
+        self.meeting.assignee = self.host_two
+        self.meeting.start()
+        self.meeting.save()
+
         self.client = Client()
 
     def test_cannot_reassign_host_when_meeting_has_started(self):
-        meeting = Meeting.objects.create(queue=self.queue, backend_type='inperson')
-        meeting.attendees.set([self.attendee_one])
-        meeting.assignee = self.host_two
-        meeting.start()
-        meeting.save()
-
-        url = f'/api/meetings/{meeting.id}/'
+        url = f'/api/meetings/{self.meeting.id}/'
         data = {
             "attendee_ids": [self.attendee_one.id],
             "assignee_id": self.host_one.id

--- a/src/officehours_api/test_views.py
+++ b/src/officehours_api/test_views.py
@@ -1,0 +1,56 @@
+# started code reference from remote-office-hours-queue/src/officehours_api/tests.py
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.test import TestCase, override_settings, RequestFactory
+from rest_framework.test import APIRequestFactory
+
+from officehours_api.models import User, Queue, Meeting
+from officehours_api.views import MeetingDetail
+
+
+class MeetingTestCase(TestCase):
+    def setUp(self):
+        self.foo = User.objects.create(username='foo', email='foo@example.com')
+        self.bar = User.objects.create(username='bar', email='bar@example.com')
+        self.baz = User.objects.create(username='baz', email='baz@example.com')
+        self.hostie = User.objects.create(
+            username='hostie', email='hostie@example.com')
+        self.queue = Queue.objects.create(
+            name='MeetingTest',
+        )
+        self.queue.hosts.set([self.hostie, self.baz])
+        self.queue.save()
+        self.exceptions = 0
+        self.factory = APIRequestFactory()
+
+    # changed the create meeting from the one already in test.py (changes a bit)
+    def create_meeting(self, host, attendees, start=False):
+        m = Meeting.objects.create(
+            queue=self.queue,
+            backend_type='inperson',
+        )
+        m.attendees.set(attendees)
+        if start:
+            m.assignee = host
+            m.start()
+            m.save()
+        return m
+
+    def test_error(self):
+        # meeting has been created where the host is self.hostie and attendees are self.foo and self.bar , the nature of the meeting is zoom
+        meeting_in_progress = self.create_meeting(self.hostie, [self.bar], True)
+        # put request to change the assignee of the meeting (not understandig what to send in this and how)
+        url = f'/api/meetings/{meeting_in_progress.id}/'
+        data = {
+            "attendee_ids": [self.bar.id],
+            "assignee_id": self.baz.id
+        }
+        
+        request = self.factory.put(url, data)
+        request.user = self.baz
+        # view response
+        response = MeetingDetail.as_view()(request, pk=meeting_in_progress.id)
+        print(response)
+
+        # self.assertEqual(response.content,
+        #                 "Can't change assignee once meeting is started!")

--- a/src/officehours_api/test_views.py
+++ b/src/officehours_api/test_views.py
@@ -1,10 +1,12 @@
 # started code reference from remote-office-hours-queue/src/officehours_api/tests.py
 import json
+from unittest import skipIf
 
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from rest_framework import status
 
+from officehours.settings import ENABLED_BACKENDS
 from officehours_api.models import Meeting, Queue
 
 
@@ -22,7 +24,9 @@ class MeetingTestCase(TestCase):
         self.host_two = User.objects.create(
             username='hosttwo', email='hosttwo@example.com'
         )
-        self.queue = Queue.objects.create(name='Test Queue')
+        self.queue = Queue.objects.create(
+            name='Test Queue', allowed_backends=['inperson', 'zoom']
+        )
         self.queue.hosts.set([self.host_one, self.host_two])
         self.queue.save()
 
@@ -49,4 +53,23 @@ class MeetingTestCase(TestCase):
         self.assertEqual(
             response_body['Meeting Detail'],
             "Can't change assignee once meeting is started!"
+        )
+
+    @skipIf('zoom' not in ENABLED_BACKENDS, 'Skipping because "zoom" backend type is not enabled')
+    def test_cannot_change_backend_type_when_meeting_has_started(self):
+        url = f'/api/meetings/{self.meeting.id}/'
+        data = {
+            "attendee_ids": [self.attendee_one.id],
+            "assignee_id": self.host_one.id,
+            "backend_type": "zoom"
+        }
+        self.client.login(username='hostone', password='rohqtest')
+        response = self.client.put(url, data, content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response_body = json.loads(response.content)
+        self.assertEqual(
+            response_body['Meeting Detail'],
+            "Can't change backend_type once meeting is started!"
         )

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -186,6 +186,12 @@ class MeetingDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdate
     serializer_class = MeetingSerializer
     permission_classes = (IsAuthenticated, IsHostOrAttendee,)
 
+    def update(self, request, *args, **kwargs):
+        try:
+            super().update(request, *args, **kwargs)
+        except Exception as e:
+            return Response({'Meeting Detail': e.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
 
 class MeetingStart(DecoupledContextMixin, LoggingMixin, APIView):
     permission_classes = (IsAuthenticated, IsAssignee,)

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -199,7 +199,10 @@ class MeetingStart(DecoupledContextMixin, LoggingMixin, APIView):
             m.start()
         except DisabledBackendException as e:
             return Response({'Start Meeting': e.message}, status=status.HTTP_400_BAD_REQUEST)
-        m.save()
+        try:
+            m.save()
+        except Exception as e:
+            return Response({'Start Meeting': e.message}, status=status.HTTP_400_BAD_REQUEST)
         serializer = MeetingSerializer(m)
         return Response(serializer.data)
 

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -12,7 +12,7 @@ from rest_framework_tracking.mixins import LoggingMixin
 from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import DjangoFilterBackend
 
-from officehours_api.exceptions import DisabledBackendException
+from officehours_api.exceptions import DisabledBackendException, MeetingStartedException
 from officehours_api.models import Attendee, Meeting, Queue
 from officehours_api.serializers import (
     ShallowUserSerializer, MyUserSerializer, ShallowQueueSerializer, QueueAttendeeSerializer,
@@ -189,8 +189,8 @@ class MeetingDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdate
     def update(self, request, *args, **kwargs):
         try:
             super().update(request, *args, **kwargs)
-        except Exception as e:
-            return Response({'Meeting Detail': e.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+        except MeetingStartedException as e:
+            return Response({'Meeting Detail': e.message}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class MeetingStart(DecoupledContextMixin, LoggingMixin, APIView):
@@ -205,10 +205,7 @@ class MeetingStart(DecoupledContextMixin, LoggingMixin, APIView):
             m.start()
         except DisabledBackendException as e:
             return Response({'Start Meeting': e.message}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            m.save()
-        except Exception as e:
-            return Response({'Start Meeting': e.message}, status=status.HTTP_400_BAD_REQUEST)
+        m.save()
         serializer = MeetingSerializer(m)
         return Response(serializer.data)
 


### PR DESCRIPTION
This PR aims to resolve #357. It also handles a possible similar case where a user tries to change the `backend_type` after the meeting is started. There are tests for both.

Credit to @anishsundaram and Divyanga Bajoria for getting this work started. This PR will supersede #376, and if this is merged, that will be closed.