### PR TITLE
Fix Manage Hosts spacing, remove unused `pull-left` class (#425)

### DIFF
--- a/src/assets/src/components/queueEditors.tsx
+++ b/src/assets/src/components/queueEditors.tsx
@@ -112,12 +112,12 @@ export function ManageHostsEditor(props: ManageHostsEditorProps) {
     const hostUsernames = props.hosts.map(h => h.username);
 
     const hostsSoFar = props.hosts.map((host, key) => (
-        <ListGroup.Item key={key}>
+        <ListGroup.Item className='p-3' key={key}>
             <UserDisplay user={host} />
             {
                 (host.id !== props.currentUser?.id)
                     && (
-                        <div className='float-right'>
+                        <div className='float-end'>
                             <RemoveButton
                                 onRemove={() => props.onRemoveHost(host)}
                                 size='sm'

--- a/src/officehours_ui/templates/base.html
+++ b/src/officehours_ui/templates/base.html
@@ -30,7 +30,7 @@
 			<div class="container">
 				<div class="navbar-brand">
           <a href="{% url 'home' %}">
-            <img src="{% static 'images/its-logo.png' %}" class="container banner-img img-responsive pull-left" alt="Remote Office Hours Queue"/>
+            <img src="{% static 'images/its-logo.png' %}" class="container banner-img img-responsive" alt="Remote Office Hours Queue"/>
           </a>
 				</div>
 				<button class="navbar-toggler ml-auto collapsed" type="button" data-bs-toggle="collapse" data-bs-target=".navbars" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
This PR aims to resolve #425.

I reviewed all the instances of `class` in the templates and `className` in the React application. I only found one other instances with `pull-left` on the navigation bar image, which I removed. This seems to have been legacy addition from before my time even, since `pull-` is from from Bootstrap 3 (see https://getbootstrap.com/docs/4.6/migration/#utilities). Removing the class resulted in no changes.

**Note:** For local testing, you'll need to create a user via the Django admin. I usually just create one called `testuser`. Then I go to a queue, and under Settings > Manage Hosts, add the extra user.