### PR TITLE
Switch to `python:3.10-slim-bullseye` (#427)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run prod
 
 #####################################################################
 
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/src/Dockerfile.openshift
+++ b/src/Dockerfile.openshift
@@ -12,7 +12,7 @@ RUN npm run prod
 
 #####################################################################
 
-FROM docker-registry.default.svc:5000/openshift/python:3.10-slim
+FROM docker-registry.default.svc:5000/openshift/python:3.10-slim-bullseye
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1


### PR DESCRIPTION
This PR aims to resolve #427.