### PR TITLE
Return response in overridden update method (#432)

### DIFF
--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -188,7 +188,7 @@ class MeetingDetail(DecoupledContextMixin, LoggingMixin, generics.RetrieveUpdate
 
     def update(self, request, *args, **kwargs):
         try:
-            super().update(request, *args, **kwargs)
+            return super().update(request, *args, **kwargs)
         except MeetingStartedException as e:
             return Response({'Meeting Detail': e.message}, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
This PR aims to resolve #432.

This is something I overlooked in #424. I've added a success test case that will fail without my fix.