### PR TITLE
Update `kustomize` process, migrate to ROSA (#441)

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -14,11 +14,11 @@ using [`kustomize`](https://kubectl.docs.kubernetes.io/guides/introduction/kusto
 
 2. Install `kustomize`.
 
-    You can install Kustomize using the command from the
+    You can install Kustomize using homebrew or using the command from the
     [website](https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/),
-    and adding version 3.8.5 (what is supported for now) as an argument.
+    and adding version 5.1.0 (what is tested/supported for now) as an argument.
     ```
-    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s 3.8.5
+    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s 5.1.0
     ```
 
 ## Updating a project

--- a/service/base/build.yaml
+++ b/service/base/build.yaml
@@ -6,7 +6,7 @@ spec:
   output:
     to:
       kind: DockerImage
-      name: docker-registry.default.svc:5000/officehours-dev/officehours:latest
+      name: image-registry.openshift-image-registry.svc:5000/officehours-dev/officehours:latest
   runPolicy: Serial
   source:
     contextDir: src

--- a/service/base/build.yaml
+++ b/service/base/build.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: web

--- a/service/base/kustomization.yaml
+++ b/service/base/kustomization.yaml
@@ -41,11 +41,6 @@ secretGenerator:
   name: secrets
   type: Opaque
 - files:
-  - secret/tls.key
-  - secret/tls.crt
-  name: web-tls
-  type: kubernetes.io/tls
-- files:
   - secret/WebHookSecretKey
   name: github
   type: Opaque

--- a/service/base/kustomization.yaml
+++ b/service/base/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  org: umich
 resources:
 - redis-deployment.yaml
 - redis-service.yaml
@@ -10,12 +8,14 @@ resources:
 - web-service.yaml
 - web-ingress.yaml
 - build.yaml
-commonLabels:
-  project: officehours
+labels:
+- includeSelectors: true
+  pairs:
+    org: umich
+    project: officehours
 namePrefix: officehours-
 secretGenerator:
-- name: secrets
-  files:
+- files:
   - secret/ALLOWED_HOSTS
   - secret/DEBUG
   - secret/SECRET_KEY
@@ -38,16 +38,17 @@ secretGenerator:
   - secret/TWILIO_AUTH_TOKEN
   - secret/TWILIO_MESSAGING_SERVICE_SID
   - secret/ZOOM_SIGN_IN_HELP
+  name: secrets
   type: Opaque
-- name: web-tls
-  type: "kubernetes.io/tls"
-  files:
+- files:
   - secret/tls.key
   - secret/tls.crt
-- name: github
-  type: Opaque
-  files:
+  name: web-tls
+  type: kubernetes.io/tls
+- files:
   - secret/WebHookSecretKey
-crds:  # Use CRDs to support OpenShift resource kinds
-- openshift-buildconfig.json
-- openshift-deploymentconfig.json
+  name: github
+  type: Opaque
+# crds:
+# - openshift-buildconfig.json
+# - openshift-deploymentconfig.json

--- a/service/base/kustomization.yaml
+++ b/service/base/kustomization.yaml
@@ -49,6 +49,6 @@ secretGenerator:
   - secret/WebHookSecretKey
   name: github
   type: Opaque
-# crds:
-# - openshift-buildconfig.json
-# - openshift-deploymentconfig.json
+crds:
+- openshift-buildconfig.json
+- openshift-deploymentconfig.json

--- a/service/base/redis-deployment.yaml
+++ b/service/base/redis-deployment.yaml
@@ -1,10 +1,9 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
   labels:
     app: redis
-  name: redis
 spec:
   replicas: 1
   strategy:
@@ -18,7 +17,7 @@ spec:
         variant: dev
     spec:
       containers:
-      - image: docker-registry.default.svc:5000/openshift/redis:7
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/redis:7
         name: redis
         command: ["redis-server", "--stop-writes-on-bgsave-error", "no", "--save", "\"\""]
         resources: {}

--- a/service/base/web-deployment.yaml
+++ b/service/base/web-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   name: web

--- a/service/base/web-ingress.yaml
+++ b/service/base/web-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web
@@ -15,13 +15,19 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-         serviceName: web
-         servicePort: 80
+          service:
+            name: web
+            port:
+              number: 80
   - host: www.dev.officehours.it.umich.edu
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-         serviceName: web
-         servicePort: 80
+          service:
+            name: web
+            port:
+              number: 80

--- a/service/base/web-ingress.yaml
+++ b/service/base/web-ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   name: web
   labels:
     app: web
+  annotations:
+    # The following triggers cert-manager to obtain a certificate automatically
+    # using the production Let’s Encrypt environment
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   tls:
   - hosts:

--- a/service/overlays/dev/kustomization.yaml
+++ b/service/overlays/dev/kustomization.yaml
@@ -1,16 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  variant: dev
-  org: umich
+labels:
+- includeSelectors: true
+  pairs:
+    org: umich
+    variant: dev
 nameSuffix: -dev
-bases:
+resources:
 - ../../base
 secretGenerator:
-  - name: secrets
-    behavior: merge
-    type: Opaque
-    files:
-    - secret/EMAIL_SUBJECT_PREFIX
-    - secret/ZOOM_CLIENT_ID
-    - secret/ZOOM_CLIENT_SECRET
+- behavior: merge
+  files:
+  - secret/EMAIL_SUBJECT_PREFIX
+  - secret/ZOOM_CLIENT_ID
+  - secret/ZOOM_CLIENT_SECRET
+  name: secrets
+  type: Opaque

--- a/service/overlays/prod/build.yaml
+++ b/service/overlays/prod/build.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/output/to/name
-  value: docker-registry.default.svc:5000/officehours/officehours:latest
+  value: image-registry.openshift-image-registry.svc:5000/officehours/officehours:latest
 - op: replace
   path: /spec/source/git/ref
   value: master

--- a/service/overlays/prod/kustomization.yaml
+++ b/service/overlays/prod/kustomization.yaml
@@ -1,40 +1,39 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  variant: prod
-  org: umich
+labels:
+- includeSelectors: true
+  pairs:
+    org: umich
+    variant: prod
 nameSuffix: -prod
-bases:
+resources:
 - ../../base
-patchesStrategicMerge:
-- tls.yaml
-patchesJson6902:
-- target:
+patches:
+- path: hostname.yaml
+  target:
     group: extensions
-    version: v1beta1
     kind: Ingress
     name: web
-  path: hostname.yaml
-- target:
-    version: v1
+    version: v1beta1
+- path: deployment.yaml
+  target:
     kind: DeploymentConfig
     name: web
-  path: deployment.yaml
-- target:
     version: v1
+- path: build.yaml
+  target:
     kind: BuildConfig
     name: web
-  path: build.yaml
-- target:
-    group: autoscaling
     version: v1
+- path: web-autoscaler.yaml
+  target:
+    group: autoscaling
     kind: HorizontalPodAutoscaler
     name: web
-  path: web-autoscaler.yaml
+    version: v1
+- path: tls.yaml
 secretGenerator:
-- name: secrets
-  behavior: merge
-  type: Opaque
+- behavior: merge
   files:
   - secret/DEBUG
   - secret/SECRET_KEY
@@ -49,9 +48,11 @@ secretGenerator:
   - secret/REDIS_HOST
   - secret/ZOOM_CLIENT_ID
   - secret/ZOOM_CLIENT_SECRET
-- name: web-tls
-  behavior: replace
-  type: "kubernetes.io/tls"
+  name: secrets
+  type: Opaque
+- behavior: replace
   files:
   - secret/tls.key
   - secret/tls.crt
+  name: web-tls
+  type: kubernetes.io/tls

--- a/service/overlays/prod/kustomization.yaml
+++ b/service/overlays/prod/kustomization.yaml
@@ -11,10 +11,10 @@ resources:
 patches:
 - path: hostname.yaml
   target:
-    group: extensions
+    group: networking.k8s.io
     kind: Ingress
     name: web
-    version: v1beta1
+    version: v1
 - path: deployment.yaml
   target:
     kind: DeploymentConfig
@@ -50,9 +50,3 @@ secretGenerator:
   - secret/ZOOM_CLIENT_SECRET
   name: secrets
   type: Opaque
-- behavior: replace
-  files:
-  - secret/tls.key
-  - secret/tls.crt
-  name: web-tls
-  type: kubernetes.io/tls

--- a/service/overlays/prod/tls.yaml
+++ b/service/overlays/prod/tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web

--- a/service/overlays/qa/build.yaml
+++ b/service/overlays/qa/build.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/output/to/name
-  value: docker-registry.default.svc:5000/officehours-qa/officehours:latest
+  value: image-registry.openshift-image-registry.svc:5000/officehours-qa/officehours:latest
 - op: replace
   path: /spec/source/git/ref
   value: master

--- a/service/overlays/qa/kustomization.yaml
+++ b/service/overlays/qa/kustomization.yaml
@@ -1,40 +1,39 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  variant: qa
-  org: umich
+labels:
+- includeSelectors: true
+  pairs:
+    org: umich
+    variant: qa
 nameSuffix: -qa
-bases:
+resources:
 - ../../base
-patchesStrategicMerge:
-- tls.yaml
-patchesJson6902:
-- target:
+patches:
+- path: hostname.yaml
+  target:
     group: extensions
-    version: v1beta1
     kind: Ingress
     name: web
-  path: hostname.yaml
-- target:
-    version: v1
+    version: v1beta1
+- path: deployment.yaml
+  target:
     kind: DeploymentConfig
     name: web
-  path: deployment.yaml
-- target:
     version: v1
+- path: build.yaml
+  target:
     kind: BuildConfig
     name: web
-  path: build.yaml
-- target:
-    group: autoscaling
     version: v1
+- path: web-autoscaler.yaml
+  target:
+    group: autoscaling
     kind: HorizontalPodAutoscaler
     name: web
-  path: web-autoscaler.yaml
+    version: v1
+- path: tls.yaml
 secretGenerator:
-- name: secrets
-  behavior: merge
-  type: Opaque
+- behavior: merge
   files:
   - secret/EMAIL_SUBJECT_PREFIX
   - secret/DEBUG
@@ -50,9 +49,11 @@ secretGenerator:
   - secret/REDIS_HOST
   - secret/ZOOM_CLIENT_ID
   - secret/ZOOM_CLIENT_SECRET
-- name: web-tls
-  behavior: replace
-  type: "kubernetes.io/tls"
+  name: secrets
+  type: Opaque
+- behavior: replace
   files:
   - secret/tls.key
   - secret/tls.crt
+  name: web-tls
+  type: kubernetes.io/tls

--- a/service/overlays/qa/kustomization.yaml
+++ b/service/overlays/qa/kustomization.yaml
@@ -11,10 +11,10 @@ resources:
 patches:
 - path: hostname.yaml
   target:
-    group: extensions
+    group: networking.k8s.io
     kind: Ingress
     name: web
-    version: v1beta1
+    version: v1
 - path: deployment.yaml
   target:
     kind: DeploymentConfig
@@ -51,9 +51,3 @@ secretGenerator:
   - secret/ZOOM_CLIENT_SECRET
   name: secrets
   type: Opaque
-- behavior: replace
-  files:
-  - secret/tls.key
-  - secret/tls.crt
-  name: web-tls
-  type: kubernetes.io/tls

--- a/service/overlays/qa/tls.yaml
+++ b/service/overlays/qa/tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web

--- a/src/Dockerfile.openshift
+++ b/src/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # build react components for production mode
-FROM docker-registry.default.svc:5000/openshift/node:18-alpine AS node-webpack
+FROM image-registry.openshift-image-registry.svc:5000/openshift/node:18-alpine AS node-webpack
 WORKDIR /usr/src/app
 
 # NOTE: package.json and webpack.config.js not likely to change between dev builds

--- a/src/Dockerfile.openshift
+++ b/src/Dockerfile.openshift
@@ -12,7 +12,7 @@ RUN npm run prod
 
 #####################################################################
 
-FROM docker-registry.default.svc:5000/openshift/python:3.10-slim-bullseye
+FROM image-registry.openshift-image-registry.svc:5000/openshift/python:3.10-slim-bullseye
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1


### PR DESCRIPTION
This PR aims to resolve #441. Changes to kustomize files were mostly arrived at by 1) running the CLI tool referenced in errors and 2) reviewing errors and then looking at the documentation for that resource type. The changes also make use of the new cert-manager functionality available in the new cluster for auto-updating and application of certificates.

Resources
- https://kubectl.docs.kubernetes.io/guides/