### PR TITLE
Handles string in URL parameters

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -444,7 +444,7 @@ export function QueuePage(props: PageProps) {
     const { queue_id } = useParams();
     if (queue_id === undefined) throw new Error("queue_id is undefined!");
     if (!props.user) throw new Error("user is undefined!");
-    const queueIdParsed = parseInt(queue_id);
+    const queueIdParsed = isNaN(parseInt(queue_id)) ? 10000000000 : parseInt(queue_id);
 
     //Setup basic state
     const [selectedBackend, setSelectedBackend] = useState(undefined as string | undefined);
@@ -577,7 +577,7 @@ export function QueuePage(props: PageProps) {
             <Dialog {...dialogState} />
             <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl}/>
             {meetingTypeDialog}
-            <Breadcrumbs currentPageTitle={queue?.name ?? queueIdParsed.toString()}/>
+            <Breadcrumbs currentPageTitle={queue?.name ?? queue_id}/>
             {loadingDisplay}
             {errorDisplay}
             {queueDisplay}

--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -445,6 +445,7 @@ export function QueuePage(props: PageProps) {
     if (queue_id === undefined) throw new Error("queue_id is undefined!");
     if (!props.user) throw new Error("user is undefined!");
     const queueIdParsed = isNaN(parseInt(queue_id)) ? 10000000000 : parseInt(queue_id);
+    const queue_id_display = parseInt(queue_id).toString()
 
     //Setup basic state
     const [selectedBackend, setSelectedBackend] = useState(undefined as string | undefined);
@@ -577,7 +578,7 @@ export function QueuePage(props: PageProps) {
             <Dialog {...dialogState} />
             <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl}/>
             {meetingTypeDialog}
-            <Breadcrumbs currentPageTitle={queue?.name ?? queue_id}/>
+            <Breadcrumbs currentPageTitle={queue?.name ?? queue_id_display}/>
             {loadingDisplay}
             {errorDisplay}
             {queueDisplay}


### PR DESCRIPTION
### PR Summary

This PR handles invalid queue IDs that are strings. Prior to this fix, if the user enters a string in the URL parameter for queue ID, it will throw an error in the backend, a Queue Connection will appear in the UI, and NaN will appear in the breadcrumbs. With this fix, the error message returned is the same as an invalid queue ID that is a number.

Fixes #422 


### Notes
I set the queue ID that is passed into useQueueWebSocket equal to a large number to obtain the proper error message. This is assuming that the large number is always an invalid queue ID. As such, if future queues are set to that number, the solution will not work as intended.

