### PR TITLE
Added Warning Message When User Inputs Email (Resolved Issue #11)

### DIFF
--- a/src/assets/src/components/home.tsx
+++ b/src/assets/src/components/home.tsx
@@ -35,9 +35,9 @@ function QueueLookup() {
                         <Button type="submit" variant="primary" disabled={emailError}>Search Queues</Button>
                     </InputGroup>
                     {emailError && (
-                        <Alert variant="warning" className="mt-2">
-                            Emails cannot be used to search queue. Please use uniqname instead.
-                        </Alert>
+                        <div style={{ margin: '5px'}}>
+                            <span style={{ color: 'red' }}>Emails cannot be used to search queue. Please use uniqname instead.</span>
+                        </div>
                     )}
                 </Form>
             </Col>

--- a/src/assets/src/components/home.tsx
+++ b/src/assets/src/components/home.tsx
@@ -36,7 +36,7 @@ function QueueLookup() {
                     </InputGroup>
                     {emailError && (
                         <Alert variant="warning" className="mt-2">
-                            Emails cannot be entered.
+                            Emails cannot be used to search queue. Please use uniqname instead.
                         </Alert>
                     )}
                 </Form>

--- a/src/assets/src/components/home.tsx
+++ b/src/assets/src/components/home.tsx
@@ -2,14 +2,22 @@ import * as React from "react";
 import { useState } from "react";
 import { MyUser } from "../models";
 import { Link } from "react-router-dom";
-import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
+import { Button, Col, Form, InputGroup, Row, Alert } from "react-bootstrap";
 
 import { ErrorDisplay, FormError, JoinedQueueAlert, Breadcrumbs } from "./common";
 import { PageProps } from "./page";
 import { useUserWebSocket } from "../services/sockets";
+import { uniqnameSchema, queueNameSchema } from "../validation";
 
 function QueueLookup() {
     const [lookup, setLookup] = useState("");
+    const [emailError, setEmailError] = useState(false);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setLookup(value);
+        setEmailError(value.includes('@'));
+    }
     return (
         <Row className="mt-3">
             <Col sm={12} md={8} lg={6}>
@@ -22,10 +30,15 @@ function QueueLookup() {
                             placeholder="Queue name or host uniqname..."
                             name="term"
                             value={lookup}
-                            onChange={(e) => setLookup(e.target.value)}
+                            onChange={handleChange}
                         />
-                        <Button type="submit" variant="primary">Search Queues</Button>
+                        <Button type="submit" variant="primary" disabled={emailError}>Search Queues</Button>
                     </InputGroup>
+                    {emailError && (
+                        <Alert variant="warning" className="mt-2">
+                            Emails cannot be entered.
+                        </Alert>
+                    )}
                 </Form>
             </Col>
         </Row>

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -37,7 +37,7 @@ interface AddAttendeeFormProps {
 function AddAttendeeForm(props: AddAttendeeFormProps) {
     const [attendee, setAttendee] = useState('');
     const [selectedBackend, setSelectedBackend] = useState(props.defaultBackend);
-    const [attendeeValidationResult, validateAndSetAttendeeResult, clearAttendeeResult] = useStringValidation(uniqnameSchema);
+    const [attendeeValidationResult, validateAndSetAttendeeResult, clearAttendeeResult] = useStringValidation(uniqnameSchema, false);
 
     if (!props.allowedBackends.has(selectedBackend)) {
         setSelectedBackend(Array.from(props.allowedBackends)[0]);

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -66,7 +66,8 @@ export const queueLocationSchema = string().defined().trim().max(100, createRema
 export const uniqnameSchema = string().defined().trim().lowercase()
     .min(3, 'Uniqnames must be at least 3 characters long.')
     .max(8, 'Uniqnames must be at most 8 characters long.')
-    .matches(/^[a-z]+$/i, 'Uniqnames cannot contain non-alphabetical characters.');
+    .matches(/^[^@]*$/, "You need to use a uniqname and not an email address")
+    .matches(/^[a-z@]+$/i, "Uniqnames cannot contain non-alphabetical characters.");
 
 
 // Type validator(s)

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -66,7 +66,7 @@ export const queueLocationSchema = string().defined().trim().max(100, createRema
 export const uniqnameSchema = string().defined().trim().lowercase()
     .min(3, 'Uniqnames must be at least 3 characters long.')
     .max(8, 'Uniqnames must be at most 8 characters long.')
-    .matches(/^[^@]*$/, "You need to use a uniqname and not an email address")
+    .matches(/^[^@]*$/, "Please use your uniqname instead of your email address.")
     .matches(/^[a-z@]+$/i, "Uniqnames cannot contain non-alphabetical characters.");
 
 

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -64,11 +64,10 @@ export const queueDescriptSchema = string().defined().trim().max(1000, createRem
 export const meetingAgendaSchema = string().defined().trim().max(100, createRemainingCharsMessage);
 export const queueLocationSchema = string().defined().trim().max(100, createRemainingCharsMessage);
 export const uniqnameSchema = string().defined().trim().lowercase()
+    .matches(/^[^@]*$/, "Please use uniqname instead of email address.")
+    .matches(/^[a-z]+$/i, "Uniqnames cannot contain non-alphabetical characters.")
     .min(3, 'Uniqnames must be at least 3 characters long.')
-    .max(8, 'Uniqnames must be at most 8 characters long.')
-    .matches(/^[^@]*$/, "Please use your uniqname instead of your email address.")
-    .matches(/^[a-z@]+$/i, "Uniqnames cannot contain non-alphabetical characters.");
-
+    .max(8, 'Uniqnames must be at most 8 characters long.');
 
 // Type validator(s)
 


### PR DESCRIPTION
PR Summary
Resolved the feature request for adding a warning message when user inputs email for adding attendees and hosts. Also added a check in the home page when user tries to input email when searching for the queue (previously uniqname@umich.edu will not render result whereas uniqname alone will, so added warning to avoid confusion). 

Note: I also implemented an optional feature (not in this commit) that will allow users to search queue by email (by stripping out the @ portions), but not sure if this is a needed feature so did not commit. 

Steps to Test
Manual Testing:
- Add attendee test: Navigate to the manage page for an existing queue. Try to type in uniq@ in the + Add Attendee section, and the message "Please use your uniqname instead of your email address." should appear. 
- Add host test: Navigate to http://localhost:8003/add_queue and try to input uniq@, a warning message should appear saying You need to use a uniqname and not email address. 
- Home queue search test: Navigate to http://localhost:8003, type in uniq@ again, and the message emails cannot be entered will appear. 

Jest / React-DOM Testing:
- Some additional automated tests are written in jest to simulate user input and DOM behavior. They are committed on the branch user-enter-email-warning-test and can be run via npm run test. 

Images:
Home Page:
<img width="707" alt="Screenshot 2024-04-18 at 10 33 41 PM" src="https://github.com/tl-its-umich-edu/remote-office-hours-queue/assets/56746786/c1916bf3-7b7d-4dd2-86f0-0fb054c71a6d">
Add Attendee:
<img width="829" alt="Screenshot 2024-04-18 at 10 47 01 PM" src="https://github.com/tl-its-umich-edu/remote-office-hours-queue/assets/56746786/a36ee499-4ea8-4879-a7a0-87e61e183a30">
Add Host:
<img width="627" alt="Screenshot 2024-04-18 at 10 47 53 PM" src="https://github.com/tl-its-umich-edu/remote-office-hours-queue/assets/56746786/c807c2bc-8a96-448d-9993-aedbd1456e9b">

