### PR TITLE
487: twilio settings check for local build

### DIFF
--- a/src/officehours_api/exceptions.py
+++ b/src/officehours_api/exceptions.py
@@ -42,6 +42,10 @@ class MeetingStartedException(Exception):
     def __init__(self, field_name: str):
         self.message = f"Can't change {field_name} once meeting is started!"
 
+class TwilioClientNotInitializedException(Exception):
+    
+        def __init__(self):
+            self.message = "Twilio client not initialized."
 
 def backend_error_handler(exc, context):
     if isinstance(exc, BackendException):

--- a/src/officehours_api/notifications.py
+++ b/src/officehours_api/notifications.py
@@ -21,7 +21,7 @@ def initialize_twilio():
         twilio_client = TwilioClient(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
         logger.info("Twilio client initialized.")
     else:
-        logger.info("Twilio client setup skipped. Twilio settings values are not set (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_MESSAGING_SERVICE_SID).")
+        logger.warning("Twilio client setup skipped. Twilio settings values are not set (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_MESSAGING_SERVICE_SID).")
         twilio_client = None
     return twilio_client
 

--- a/src/officehours_api/notifications.py
+++ b/src/officehours_api/notifications.py
@@ -6,24 +6,26 @@ from django.conf import settings
 from django.dispatch import receiver
 from django.db.models.signals import pre_delete, post_save
 from django.contrib.sites.models import Site
+from django.http import HttpResponseServerError
 from django.urls import reverse
 
+from officehours_api.exceptions import TwilioClientNotInitializedException
 from twilio.rest import Client as TwilioClient
 
 from officehours_api.models import Queue, Meeting, MeetingStatus
 
-def initialize_twilio():
-    logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
+def initialize_twilio():
     if (settings.TWILIO_ACCOUNT_SID and settings.TWILIO_AUTH_TOKEN and settings.TWILIO_MESSAGING_SERVICE_SID):
         twilio_client = TwilioClient(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
         logger.info("Twilio client initialized.")
     else:
         logger.info("Twilio client setup skipped. Twilio settings values are not set (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_MESSAGING_SERVICE_SID).")
         twilio_client = None
-    return logger, twilio_client
+    return twilio_client
 
-logger, twilio = initialize_twilio()
+twilio = initialize_twilio()
 
 # `reverse()` at the module level breaks `/admin`, so defer it by wrapping it in a function.
 def build_addendum(domain: str):
@@ -47,6 +49,8 @@ async def send_one_time_password(phone_number: str, otp_token: str):
 
     domain = await get_current_domain(Site)
     try:
+        if twilio is None:
+            raise TwilioClientNotInitializedException()
         twilio.messages.create(
             messaging_service_sid=settings.TWILIO_MESSAGING_SERVICE_SID,
             to=phone_number,
@@ -56,9 +60,9 @@ async def send_one_time_password(phone_number: str, otp_token: str):
             ),
         )
         return True
-    except:
-        logger.exception(f"Error while sending OTP to {phone_number}")
-        return False
+    except Exception as e:
+        logger.exception(f"Error while sending OTP to {phone_number}:{e}")
+        raise e
 
 def notify_meeting_started(started: Meeting):
     phone_numbers = list(

--- a/src/officehours_api/notifications.py
+++ b/src/officehours_api/notifications.py
@@ -12,10 +12,18 @@ from twilio.rest import Client as TwilioClient
 
 from officehours_api.models import Queue, Meeting, MeetingStatus
 
-logger = logging.getLogger(__name__)
+def initialize_twilio():
+    logger = logging.getLogger(__name__)
 
-twilio = TwilioClient(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
+    if (settings.TWILIO_ACCOUNT_SID and settings.TWILIO_AUTH_TOKEN and settings.TWILIO_MESSAGING_SERVICE_SID):
+        twilio_client = TwilioClient(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
+        logger.info("Twilio client initialized.")
+    else:
+        logger.info("Twilio client setup skipped. Twilio settings values are not set (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_MESSAGING_SERVICE_SID).")
+        twilio_client = None
+    return logger, twilio_client
 
+logger, twilio = initialize_twilio()
 
 # `reverse()` at the module level breaks `/admin`, so defer it by wrapping it in a function.
 def build_addendum(domain: str):


### PR DESCRIPTION
Skip over the initialization of Twilio client when the settings are not set locally, and add some helpful logs.

Test Plan:
1. See if local build without Twilio settings runs properly
2. Try running the app with test Twilio settings 
3. Verify that OTP texting service works with Twilio settings (this is what loads the notifications.py import)