### PR TITLE
#197 Handle meetings with no attendees, add delete action

### DIFF
--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -80,13 +80,20 @@ interface UnstartedMeetingEditorProps extends MeetingEditorProps, AssigneeSelect
 }
 
 function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
-    const attendee = props.meeting.attendees[0];
+    const attendee = props.meeting.attendees[0] ?? null;
     if (!attendee) return (
         <>
         <td>No attendee</td>
         <td></td>
         <td>Invalid meeting ID: {props.meeting.id}</td>
-        <td></td>
+        <td>
+            <RemoveButton
+                onRemove={() => props.onRemoveMeeting(props.meeting)}
+                size="sm"
+                screenReaderLabel={`Remove Meeting ${props.meeting.id} with no attendee`}
+                disabled={props.disabled}
+            />
+        </td>
         </>
     );
     const attendeeString = `${attendee.first_name} ${attendee.last_name}`;
@@ -138,7 +145,22 @@ function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
 }
 
 function StartedMeetingEditor (props: MeetingEditorProps) {
-    const attendee = props.meeting.attendees[0];
+    const attendee = props.meeting.attendees[0] ?? null;
+    if (!attendee) return (
+        <>
+        <td>No attendee</td>
+        <td></td>
+        <td>Invalid meeting ID: {props.meeting.id}</td>
+        <td>
+            <RemoveButton
+                onRemove={() => props.onRemoveMeeting(props.meeting)}
+                size="sm"
+                screenReaderLabel={`Remove Meeting ${props.meeting.id} with no attendee`}
+                disabled={props.disabled}
+            />
+        </td>
+        </>
+    );
     const attendeeString = `${attendee.first_name} ${attendee.last_name}`;
     const isHost = props.user.id === props.meeting.assignee!.id;
     const joinUrl = isHost

--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -85,7 +85,7 @@ function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
         <>
         <td>No attendee</td>
         <td></td>
-        <td>Invalid meeting ID: {props.meeting.id}</td>
+        <td>Invalid meeting ID: {props.meeting.id}. Please remove this meeting</td>
         <td>
             <RemoveButton
                 onRemove={() => props.onRemoveMeeting(props.meeting)}
@@ -150,7 +150,7 @@ function StartedMeetingEditor (props: MeetingEditorProps) {
         <>
         <td>No attendee</td>
         <td></td>
-        <td>Invalid meeting ID: {props.meeting.id}</td>
+        <td>Invalid meeting ID: {props.meeting.id}. Please remove this meeting</td>
         <td>
             <RemoveButton
                 onRemove={() => props.onRemoveMeeting(props.meeting)}

--- a/src/assets/src/components/meetingTables.tsx
+++ b/src/assets/src/components/meetingTables.tsx
@@ -79,13 +79,12 @@ interface UnstartedMeetingEditorProps extends MeetingEditorProps, AssigneeSelect
     onStartMeeting: (m: Meeting) => void;
 }
 
-function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
-    const attendee = props.meeting.attendees[0] ?? null;
-    if (!attendee) return (
-        <>
+const InvalidMeeting = (props: MeetingEditorProps) => {
+    return (
+<>
         <td>No attendee</td>
         <td></td>
-        <td>Invalid meeting ID: {props.meeting.id}. Please remove this meeting</td>
+        <td>Invalid meeting ID: {props.meeting.id}. Please remove this meeting.</td>
         <td>
             <RemoveButton
                 onRemove={() => props.onRemoveMeeting(props.meeting)}
@@ -96,6 +95,13 @@ function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
         </td>
         </>
     );
+
+}
+
+function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
+    const attendee = props.meeting.attendees[0] ?? null;
+    if (!attendee) return <InvalidMeeting {...props} />;
+
     const attendeeString = `${attendee.first_name} ${attendee.last_name}`;
     const assignee = props.meeting.assignee;
 
@@ -146,21 +152,8 @@ function UnstartedMeetingEditor (props: UnstartedMeetingEditorProps) {
 
 function StartedMeetingEditor (props: MeetingEditorProps) {
     const attendee = props.meeting.attendees[0] ?? null;
-    if (!attendee) return (
-        <>
-        <td>No attendee</td>
-        <td></td>
-        <td>Invalid meeting ID: {props.meeting.id}. Please remove this meeting</td>
-        <td>
-            <RemoveButton
-                onRemove={() => props.onRemoveMeeting(props.meeting)}
-                size="sm"
-                screenReaderLabel={`Remove Meeting ${props.meeting.id} with no attendee`}
-                disabled={props.disabled}
-            />
-        </td>
-        </>
-    );
+    if (!attendee) return <InvalidMeeting {...props} />;
+
     const attendeeString = `${attendee.first_name} ${attendee.last_name}`;
     const isHost = props.user.id === props.meeting.assignee!.id;
     const joinUrl = isHost

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -287,7 +287,7 @@ export function QueueManagerPage(props: PageProps) {
     const confirmRemoveMeeting = (m: Meeting) => {
         setStateAndOpenDialog(
             "Remove Meeting?",
-            `Are you sure you want to remove your meeting with ${m.attendees[0].first_name} ${m.attendees[0].last_name}?`,
+            m.attendees[0] ? `Are you sure you want to remove your meeting with ${m.attendees[0].first_name} ${m.attendees[0].last_name}?` : "Are you sure you want to remove this meeting?",
             () => doRemoveMeeting(m)
         );
     }


### PR DESCRIPTION
#197 Addresses the issue we've been seeing with meetings without attendees. My solution is to just handle the issue client-side, allowing users to view all affected meetings and manually remove them. 

Test plan to replicate local development environment:
1. On a manage meeting page, add a user to the meeting queue (for in-person meeting)
2. Click "ready for attendee" to admit the user to the "Meetings in Progress" section
3. In local DB, delete the attendee from the officehours_api_attendee table (where meeting_id is from the id from officehours_api_meeting table): `delete from officehours_api_attendee where meeting_id={meeting_id}`
4. On browser, open the console and refresh the page. You should see a meeting with the message "Invalid meeting ID:" and no attendee. It should have a trash icon to delete the meeting
5. Delete the meeting by pressing the delete button and confirming. Double check the database to see that the meeting info is fully cleared

To test the meeting without attendees in just the Meeting Queue, repeat the above but skip over step 2