### PR TITLE
Issue 422: handle urls

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -444,7 +444,6 @@ export function QueuePage(props: PageProps) {
     const { queue_id } = useParams();
     if (queue_id === undefined) throw new Error("queue_id is undefined!");
     if (!props.user) throw new Error("user is undefined!");
-    const queueIdParsed = parseInt(queue_id);
 
     //Setup basic state
     const [selectedBackend, setSelectedBackend] = useState(undefined as string | undefined);
@@ -461,7 +460,7 @@ export function QueuePage(props: PageProps) {
         }
         setQueue(q);
     }
-    const queueWebSocketError = useQueueWebSocket(queueIdParsed, setQueueWrapped);
+    const queueWebSocketError = useQueueWebSocket(queue_id, setQueueWrapped);
     const [myUser, setMyUser] = useState(undefined as MyUser | undefined);
     const userWebSocketError = useUserWebSocket(props.user!.id, (u) => setMyUser(u as MyUser));
     const [showMeetingTypeDialog, setShowMeetingTypeDialog] = useState(false);
@@ -577,7 +576,7 @@ export function QueuePage(props: PageProps) {
             <Dialog {...dialogState} />
             <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl}/>
             {meetingTypeDialog}
-            <Breadcrumbs currentPageTitle={queue?.name ?? queueIdParsed.toString()}/>
+            <Breadcrumbs currentPageTitle={queue?.name ?? queue_id.toString()}/>
             {loadingDisplay}
             {errorDisplay}
             {queueDisplay}

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -250,7 +250,6 @@ export function QueueManagerPage(props: PageProps) {
     let { queue_id } = useParams()
     if (queue_id === undefined) throw new Error("queue_id is undefined!");
     if (!props.user) throw new Error("user is undefined!");
-    // const queueIdParsed = parseInt(queue_id);
 
     // Set up basic state
     const [queue, setQueue] = useState(undefined as QueueHost | undefined);
@@ -266,7 +265,6 @@ export function QueueManagerPage(props: PageProps) {
             setAuthError(new Error("You are not a host of this queue. If you believe you are seeing this message in error, contact the queue host(s)."));
         }
     }
-    // const queueWebSocketError = useQueueWebSocket(queueIdParsed, setQueueChecked);
     const queueWebSocketError = useQueueWebSocket(queue_id, setQueueChecked);
     const [visibleMeetingDialog, setVisibleMeetingDialog] = useState(undefined as Meeting | undefined);
 
@@ -354,7 +352,6 @@ export function QueueManagerPage(props: PageProps) {
             <Dialog {...dialogState} />
             <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl} />
             <MeetingInfoDialog backends={props.backends} meeting={visibleMeetingDialog} onClose={() => setVisibleMeetingDialog(undefined)} />
-            {/* <Breadcrumbs currentPageTitle={queue?.name ?? queueIdParsed.toString()} intermediatePages={[{title: "Manage", href: "/manage"}]} /> */}
             <Breadcrumbs currentPageTitle={queue?.name ?? queue_id.toString()} intermediatePages={[{title: "Manage", href: "/manage"}]} />
             {loadingDisplay}
             {errorDisplay}

--- a/src/assets/src/components/queueManager.tsx
+++ b/src/assets/src/components/queueManager.tsx
@@ -250,7 +250,7 @@ export function QueueManagerPage(props: PageProps) {
     let { queue_id } = useParams()
     if (queue_id === undefined) throw new Error("queue_id is undefined!");
     if (!props.user) throw new Error("user is undefined!");
-    const queueIdParsed = parseInt(queue_id);
+    // const queueIdParsed = parseInt(queue_id);
 
     // Set up basic state
     const [queue, setQueue] = useState(undefined as QueueHost | undefined);
@@ -266,7 +266,8 @@ export function QueueManagerPage(props: PageProps) {
             setAuthError(new Error("You are not a host of this queue. If you believe you are seeing this message in error, contact the queue host(s)."));
         }
     }
-    const queueWebSocketError = useQueueWebSocket(queueIdParsed, setQueueChecked);
+    // const queueWebSocketError = useQueueWebSocket(queueIdParsed, setQueueChecked);
+    const queueWebSocketError = useQueueWebSocket(queue_id, setQueueChecked);
     const [visibleMeetingDialog, setVisibleMeetingDialog] = useState(undefined as Meeting | undefined);
 
     const [myUser, setMyUser] = useState(undefined as MyUser | undefined);
@@ -353,7 +354,8 @@ export function QueueManagerPage(props: PageProps) {
             <Dialog {...dialogState} />
             <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl} />
             <MeetingInfoDialog backends={props.backends} meeting={visibleMeetingDialog} onClose={() => setVisibleMeetingDialog(undefined)} />
-            <Breadcrumbs currentPageTitle={queue?.name ?? queueIdParsed.toString()} intermediatePages={[{title: "Manage", href: "/manage"}]} />
+            {/* <Breadcrumbs currentPageTitle={queue?.name ?? queueIdParsed.toString()} intermediatePages={[{title: "Manage", href: "/manage"}]} /> */}
+            <Breadcrumbs currentPageTitle={queue?.name ?? queue_id.toString()} intermediatePages={[{title: "Manage", href: "/manage"}]} />
             {loadingDisplay}
             {errorDisplay}
             {queueManager}

--- a/src/assets/src/hooks/useWebSocket.ts
+++ b/src/assets/src/hooks/useWebSocket.ts
@@ -39,7 +39,7 @@ export const useWebSocket = <T>(url: string, onUpdate: (content: T) => void, onD
                 setError(new Error("The resource you're looking for does not exist. Maybe it was deleted?"));
                 ws.close();
             } else if (e.code === 4405) { // Custom 4404
-                setError(new Error("It looks like you entered an invalid queue ID!"));
+                setError(new Error("Oops! It looks like you've entered an invalid queue ID in the URL. Please make sure to enter the correct numeric queue ID. You can find the accurate queue ID in your 'Manage Queue' list for reference."));
                 ws.close();
             } else if (e.code === 1011) { // Equivalent of HTTP 500
                 setError(new Error("Sorry, there was a system error. Please try refreshing. If you continue to receive this error, contact the ITS Service Center."));

--- a/src/assets/src/hooks/useWebSocket.ts
+++ b/src/assets/src/hooks/useWebSocket.ts
@@ -38,6 +38,9 @@ export const useWebSocket = <T>(url: string, onUpdate: (content: T) => void, onD
             if (e.code === 4404) { // Equivalent of HTTP 404
                 setError(new Error("The resource you're looking for does not exist. Maybe it was deleted?"));
                 ws.close();
+            } else if (e.code === 4405) { // Custom 4404
+                setError(new Error("It looks like you entered an invalid queue ID!"));
+                ws.close();
             } else if (e.code === 1011) { // Equivalent of HTTP 500
                 setError(new Error("Sorry, there was a system error. Please try refreshing. If you continue to receive this error, contact the ITS Service Center."));
                 ws.close();

--- a/src/assets/src/services/sockets.ts
+++ b/src/assets/src/services/sockets.ts
@@ -5,7 +5,7 @@ const getProtocol = () => {
     return location.protocol === "https:" ? "wss:" : "ws:";
 }
 
-export const useQueueWebSocket = (queue_id: number, onUpdate: (q: QueueHost | QueueAttendee | undefined) => void) => {
+export const useQueueWebSocket = (queue_id: any, onUpdate: (q: QueueHost | QueueAttendee | undefined) => void) => {
     return useWebSocket(
         `${getProtocol()}//${location.host}/ws/queues/${queue_id}/`,
         onUpdate,


### PR DESCRIPTION
fixes #422 

To test locally, start local environment and then go to `http://localhost:8003/queue/<any-string>/` and `http://localhost:8003/manage/<any-string>/` to check that the breadcrumb matches the invalid one that was entered and error message.

Note: once Django and websocket libraries are updated, we can try adding the` <any-string>` into the error message, but for now this part of the fix is probably more trouble than it's worth.