### PR TITLE
Fixes #460 - Change qa hostnames to test

### DIFF
--- a/service/overlays/test/hostname.yaml
+++ b/service/overlays/test/hostname.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/rules/0/host
-  value: qa.officehours.it.umich.edu
+  value: test.officehours.it.umich.edu
 - op: add
   path: /spec/rules/1/host
-  value: www.qa.officehours.it.umich.edu
+  value: www.test.officehours.it.umich.edu

--- a/service/overlays/test/tls.yaml
+++ b/service/overlays/test/tls.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   tls:
   - hosts:
-    - qa.officehours.it.umich.edu
-    - www.qa.officehours.it.umich.edu
+    - test.officehours.it.umich.edu
+    - www.test.officehours.it.umich.edu
     secretName: web-tls


### PR DESCRIPTION
Fixes #460 Fix reverted in 1.11.0 because we needed more work.