### PR TITLE
Remove trailing slash from API endpoints (iss. #582)

### DIFF
--- a/src/officehours_api/urls.py
+++ b/src/officehours_api/urls.py
@@ -5,22 +5,21 @@ from officehours_api import views
 
 urlpatterns = [
     path('', views.api_root, name='api-root'),
-    path('users/', views.UserList.as_view(), name='user-list'),
-    path('users/<int:pk>/', views.UserDetail.as_view(), name='user-detail'),
-    path('users/<int:pk>/otp/', views.UserOTP.as_view(), name='user-otp'),
-    path('users/<str:username>/', views.UserUniqnameDetail.as_view(), name='user-uniqname-detail'),
-    path('queues/', views.QueueList.as_view(), name='queue-list'),
-    path('queues/<int:pk>/', views.QueueDetail.as_view(), name='queue-detail'),
-    path('queues/<int:pk>/hosts/<int:user_id>/', views.QueueHostDetail.as_view(), name='queuehost-detail'),
-    path('queues_search/', views.QueueListSearch.as_view(), name='queue-search'),
-    path('meetings/', views.MeetingList.as_view(), name='meeting-list'),
-    path('meetings/<int:pk>/', views.MeetingDetail.as_view(), name='meeting-detail'),
+    path('users', views.UserList.as_view(), name='user-list'),
+    path('users/<int:pk>', views.UserDetail.as_view(), name='user-detail'),
+    path('users/<int:pk>/otp', views.UserOTP.as_view(), name='user-otp'),
+    path('users/<str:username>', views.UserUniqnameDetail.as_view(), name='user-uniqname-detail'),
+    path('queues', views.QueueList.as_view(), name='queue-list'),
+    path('queues/<int:pk>', views.QueueDetail.as_view(), name='queue-detail'),
+    path('queues/<int:pk>/hosts/<int:user_id>', views.QueueHostDetail.as_view(), name='queuehost-detail'),
+    path('queues_search', views.QueueListSearch.as_view(), name='queue-search'),
+    path('meetings', views.MeetingList.as_view(), name='meeting-list'),
+    path('meetings/<int:pk>', views.MeetingDetail.as_view(), name='meeting-detail'),
     path('meetings/<int:pk>/start', views.MeetingStart.as_view(), name='meeting-start'),
-    path('attendees/', views.AttendeeList.as_view(), name='attendee-list'),
-    path('attendees/<int:pk>/', views.AttendeeDetail.as_view(), name='attendee-detail'),
-    path('export_meeting_start_logs/<int:queue_id>/', views.ExportMeetingStartLogs.as_view(), name='export-meeting-start-logs-with-queue'),
-    path('export_meeting_start_logs/', views.ExportMeetingStartLogs.as_view(), name='export-meeting-start-logs'),
-
+    path('attendees', views.AttendeeList.as_view(), name='attendee-list'),
+    path('attendees/<int:pk>', views.AttendeeDetail.as_view(), name='attendee-detail'),
+    path('export_meeting_start_logs/<int:queue_id>', views.ExportMeetingStartLogs.as_view(), name='export-meeting-start-logs-with-queue'),
+    path('export_meeting_start_logs', views.ExportMeetingStartLogs.as_view(), name='export-meeting-start-logs'),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
After this change, requesting endpoints with a trailing slash results in a HTTP 404 (not found) error.  Following this change, it's important to check other parts of the application to ensure they do not use a trailing slash when calling API endpoints.