### PR TITLE
Fixes #559: No newline in EMAIL_SUBJECT_PREFIX.

### DIFF
--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -296,8 +296,8 @@ LOGGING_METHODS = csv_to_list(
 
 
 # Email
-EMAIL_HOST = os.getenv('EMAIL_HOST')
-EMAIL_SUBJECT_PREFIX = os.getenv('EMAIL_SUBJECT_PREFIX', '[ROHQ] ')
+EMAIL_HOST = os.getenv('EMAIL_HOST').strip()
+EMAIL_SUBJECT_PREFIX = os.getenv('EMAIL_SUBJECT_PREFIX', '[ROHQ] ').strip()
 
 ADMINS = [('Admins', os.getenv('ADMIN_EMAIL'))]
 MANAGERS = ADMINS

--- a/src/officehours/test_settings.py
+++ b/src/officehours/test_settings.py
@@ -78,6 +78,7 @@ class ChannelLayersConfigTest(TestCase):
             self.assertEqual(settings.EMAIL_HOST, settings.EMAIL_HOST.strip())
         self.assertTrue(settings.EMAIL_SUBJECT_PREFIX.startswith('['))
         self.assertTrue(settings.EMAIL_SUBJECT_PREFIX.endswith('] '))
+        self.assertEqual(settings.EMAIL_SUBJECT_PREFIX, settings.EMAIL_SUBJECT_PREFIX.strip())
 
     def test_admins_and_managers(self):
         self.assertIsInstance(settings.ADMINS, list)


### PR DESCRIPTION
Added an extra assert statement to ensure EMAIL_SUBJECT_PREFIX doesn't contain a newline character. I made sure to stay consistent with the existing tests for redis_host as mentioned in #473.