### PR TITLE
Issue with PR #587: None type error

### DIFF
--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -296,7 +296,7 @@ LOGGING_METHODS = csv_to_list(
 
 
 # Email
-EMAIL_HOST = os.getenv('EMAIL_HOST').strip()
+EMAIL_HOST = os.getenv('EMAIL_HOST', 'localhost').strip()
 EMAIL_SUBJECT_PREFIX = os.getenv('EMAIL_SUBJECT_PREFIX', '[ROHQ] ').strip()
 
 ADMINS = [('Admins', os.getenv('ADMIN_EMAIL'))]

--- a/src/officehours/settings.py
+++ b/src/officehours/settings.py
@@ -296,8 +296,8 @@ LOGGING_METHODS = csv_to_list(
 
 
 # Email
-EMAIL_HOST = os.getenv('EMAIL_HOST')
-EMAIL_SUBJECT_PREFIX = os.getenv('EMAIL_SUBJECT_PREFIX', '[ROHQ] ')
+EMAIL_HOST = os.getenv('EMAIL_HOST').strip()
+EMAIL_SUBJECT_PREFIX = os.getenv('EMAIL_SUBJECT_PREFIX', '[ROHQ] ').strip()
 
 ADMINS = [('Admins', os.getenv('ADMIN_EMAIL'))]
 MANAGERS = ADMINS

--- a/src/officehours/test_settings.py
+++ b/src/officehours/test_settings.py
@@ -78,6 +78,7 @@ class ChannelLayersConfigTest(TestCase):
             self.assertEqual(settings.EMAIL_HOST, settings.EMAIL_HOST.strip())
         self.assertTrue(settings.EMAIL_SUBJECT_PREFIX.startswith('['))
         self.assertTrue(settings.EMAIL_SUBJECT_PREFIX.endswith('] '))
+        self.assertEqual(settings.EMAIL_SUBJECT_PREFIX, settings.EMAIL_SUBJECT_PREFIX.strip())
 
     def test_admins_and_managers(self):
         self.assertIsInstance(settings.ADMINS, list)


### PR DESCRIPTION
Fixed the issue raised by trying to apply .strip() to a None type in the case where no email host is specified.

> @jadfalaoui I got the following error with `docker compose up`, after this PR merge:
> 
> "remote-office-hours-queue-web-1 | File "/usr/src/app/officehours/settings.py", line 299, in remote-office-hours-queue-web-1 | EMAIL_HOST = os.getenv('EMAIL_HOST').strip() remote-office-hours-queue-web-1 | AttributeError: 'NoneType' object has no attribute 'strip'"
> 
> Neither `EMAIL_HOST` or `EMAIL_SUBJECT_PREFIX` is defined as environment variable inside the docker-compose.yaml file.
> 
> Could you please fix the above error?

