### PR TITLE
Adding dependabot.yml file for auto updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for python
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/src" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "django"
+        versions:
+          - "> 4.2"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
+    groups:
+      all-python-dependencies:
+        patterns: ["*"]
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/src"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-npm-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
Fixes #593

This file mostly exists so that grouped updates can work as expected and django is held back to 4. 