### PR TITLE
use test imagestream for deployment (iss. #561)

### DIFF
--- a/service/overlays/prod/deployment.yaml
+++ b/service/overlays/prod/deployment.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: image-registry.openshift-image-registry.svc:5000/officehours-prod/officehours:latest
+  value: image-registry.openshift-image-registry.svc:5000/officehours-test/officehours:latest
 - op: replace
   path: /spec/selector/variant
   value: prod


### PR DESCRIPTION
Resolves #561.

Update production overlay to refer to test imagestream tag, defined in the test environment.