### PR TITLE
Fixes #561 - Updates to service files

### DIFF
--- a/service/base/imagestream.yaml
+++ b/service/base/imagestream.yaml
@@ -7,6 +7,6 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: ghcr.io/tl-its-umich-edu/remote-office-hours-queue:latest
+        name: ghcr.io/tl-its-umich-edu/remote-office-hours-queue:master
       importPolicy:
         scheduled: true

--- a/service/base/web-deployment.yaml
+++ b/service/base/web-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: docker-registry.default.svc:5000/officehours-dev/officehours:latest
+        image: image-registry.openshift-image-registry.svc:5000/officehours-dev/officehours-rohq-latest-at-ghcr-test:latest
         ports:
         - containerPort: 8001
         envFrom:
@@ -42,7 +42,7 @@ spec:
       automatic: false
       from:
         kind: "ImageStreamTag"
-        name: "officehours:latest"
+        name: "officehours-rohq-latest-at-ghcr-test:latest"
         namespace: "officehours-dev"
       containerNames:
       - "web"

--- a/service/overlays/prod/deployment.yaml
+++ b/service/overlays/prod/deployment.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: rohq-latest-at-ghcr:latest
+  value: image-registry.openshift-image-registry.svc:5000/officehours-rohq-latest-at-ghcr-test/officehours:latest 
 - op: replace
   path: /spec/selector/variant
   value: prod

--- a/service/overlays/test/deployment.yaml
+++ b/service/overlays/test/deployment.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: image-registry.openshift-image-registry.svc:5000/officehours-test/officehours:latest
+  value: image-registry.openshift-image-registry.svc:5000/officehours-test/officehours-rohq-latest-at-ghcr-test:latest
 - op: replace
   path: /spec/selector/variant
   value: test


### PR DESCRIPTION
1. The name on the package in https://github.com/tl-its-umich-edu/remote-office-hours-queue/pkgs/container/remote-office-hours-queue was master, not latest so updated that
2. Needed to change image names to the full value new Imagestream of mage-registry.openshift-image-registry.svc:5000/officehours-dev/officehours-rohq-latest-at-ghcr-test