### PR TITLE
feat: Add email searching logic for queue searches

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-DEBUG=True
+#DEBUG=False
 #ALLOWED_HOSTS=*
 #DATABASE_URL=postgresql://admin:admin_pw@database/admin
 #FEEDBACK_EMAIL=office-hours-devs@umich.edu

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-#DEBUG=False
+DEBUG=True
 #ALLOWED_HOSTS=*
 #DATABASE_URL=postgresql://admin:admin_pw@database/admin
 #FEEDBACK_EMAIL=office-hours-devs@umich.edu

--- a/src/assets/src/components/home.tsx
+++ b/src/assets/src/components/home.tsx
@@ -11,12 +11,9 @@ import { uniqnameSchema, queueNameSchema } from "../validation";
 
 function QueueLookup() {
     const [lookup, setLookup] = useState("");
-    const [emailError, setEmailError] = useState(false);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const value = e.target.value;
-        setLookup(value);
-        setEmailError(value.includes('@'));
+        setLookup(e.target.value);
     }
     return (
         <Row className="mt-3">
@@ -32,13 +29,8 @@ function QueueLookup() {
                             value={lookup}
                             onChange={handleChange}
                         />
-                        <Button type="submit" variant="primary" disabled={emailError}>Search Queues</Button>
+                        <Button type="submit" variant="primary">Search Queues</Button>
                     </InputGroup>
-                    {emailError && (
-                        <div style={{ margin: '5px'}}>
-                            <span style={{ color: 'red' }}>Emails cannot be used to search queue. Please use uniqname instead.</span>
-                        </div>
-                    )}
                 </Form>
             </Col>
         </Row>

--- a/src/assets/src/validation.ts
+++ b/src/assets/src/validation.ts
@@ -64,10 +64,10 @@ export const queueDescriptSchema = string().defined().trim().max(1000, createRem
 export const meetingAgendaSchema = string().defined().trim().max(100, createRemainingCharsMessage);
 export const queueLocationSchema = string().defined().trim().max(100, createRemainingCharsMessage);
 export const uniqnameSchema = string().defined().trim().lowercase()
-    .matches(/^[^@]*$/, "Please use uniqname instead of email address.")
-    .matches(/^[a-z]+$/i, "Uniqnames cannot contain non-alphabetical characters.")
+    .matches(/^[a-z@.]+$/i, "Uniqnames or emails can only contain letters, @, and dots.")
     .min(3, 'Uniqnames must be at least 3 characters long.')
-    .max(8, 'Uniqnames must be at most 8 characters long.');
+    // FIXME: Not sure is the best "max" length
+    .max(50, 'Uniqnames or emails must be at most 50 characters long.');
 
 // Type validator(s)
 

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -194,7 +194,7 @@ class QueueListSearch(DecoupledContextMixin, generics.ListAPIView):
     queryset = Queue.objects.all()
     serializer_class = ShallowQueueSerializer
     filter_backends = [filters.SearchFilter, DjangoFilterBackend]
-    search_fields = ['name', '=hosts__username']
+    search_fields = ['name', '=hosts__username', '=hosts__email']
     filterset_fields = ['status']
 
 


### PR DESCRIPTION
**Summary:** This resolves issue #480 

**Previous Problem**: The user was not able to search by email in the search box for finding queues. For example, if a user wanted to search "someuniqname@umich.edu", it wouldn't allow for that.

**Attempted solution:**

1. Remove the error on the home page "Emails cannot be used to search queue...". This includes removing logic that blocked or warned against searching with email addresses. Removed the disabled button logic as well.
2. Updated validation to allow both uniqnames and email addresses.
3. Updated the QueueListSearch view to include "=hosts_email" in search_fields.

**Result**:
Users can now search for queues using either uniqnames or email addresses that exactly match (ex: uniqname@umich.edu instead of uniqname@umich).

**Questions:**
For the validation, I wasn't sure what should be the max length for a uniqname and email combo (FIXME comment). Also, not sure if this is the correct overall logic of matching exact email addresses, hoping for more review. Thank you!

![Screenshot 2025-05-14 152057](https://github.com/user-attachments/assets/5834ce22-ebf5-4c13-bb1a-588bc46c23ff)
![Screenshot 2025-05-14 152035](https://github.com/user-attachments/assets/ac70d78e-8847-45aa-964f-d3604f7ba98e)
![Screenshot 2025-05-14 152029](https://github.com/user-attachments/assets/9662e82e-c873-4174-ab55-2fda301cbd7c)
