### PR TITLE
fix: removed passcode form from zoom meeting, not required anymore

### DIFF
--- a/src/officehours_api/patches/pyzoom_patch.py
+++ b/src/officehours_api/patches/pyzoom_patch.py
@@ -1,0 +1,39 @@
+from pyzoom._client import MeetingsComponent
+from pyzoom import schemas
+
+def patched_create_meeting(
+    self: MeetingsComponent,
+    user_id: str,
+    topic: str,
+    start_time: str,
+    duration_min: int,
+    timezone: str = None,
+    password: str = None,    # Explicitly None if no password
+    default_password: bool = False,
+    settings: schemas.ZoomMeetingSettings = None,
+    type_: int = 2
+):
+    endpoint = f"/users/{user_id}/meetings"
+    
+    body = {
+        "topic": topic,
+        "type": type_,
+        "start_time": start_time,
+        "duration": duration_min,
+        "timezone": timezone or self.timezone,
+        "default_password": default_password,
+    }
+
+    if password is not None:
+        body["password"] = password
+
+    if settings:
+        body["settings"] = settings.model_dump()
+    else:
+        pass
+
+    response = self._client.post(endpoint, body=body)
+    
+    return response.json()
+
+MeetingsComponent.create_meeting = patched_create_meeting


### PR DESCRIPTION
Summary: fixes #657 (has details on how to reproduce error aswell)

Fixes this issue by creating a "patched" work around, where we specify `password` to be `None` and `default_password=False`. I believe that in `pyzoom`, there is no option `default_password`, which would be the way to fix this error by setting it to `False`, and removing the `password` parameter as well.

So, I created a `patched_create_meeting` method as recommended by @jonespm to temporarily fix this error.

After making the changes, we get the below:

![Screenshot 2025-05-30 151913](https://github.com/user-attachments/assets/f8fa0460-6cd4-4ace-8a02-b3223b4715d6)
