### PR TITLE
fix: add attendee's full name or email to the zoom titles

### DIFF
--- a/src/officehours_api/backends/zoom.py
+++ b/src/officehours_api/backends/zoom.py
@@ -138,7 +138,7 @@ class Backend(BackendBase):
         return ZoomClient(cls._get_access_token(user))
 
     @classmethod
-    def _create_meeting(cls, user: User) -> ZoomMeeting:
+    def _create_meeting(cls, user: User, attendee_name: str = None) -> ZoomMeeting:
         """Creates a Zoom meeting for the given user."""
         client = cls._get_client(user)
         meeting_settings = ZoomMeetingSettings(
@@ -160,10 +160,14 @@ class Backend(BackendBase):
             waiting_room=True,
             watermark=False)
 
+        topic = 'Remote Office Hours Queue Meeting'
+        if attendee_name:
+            topic = f'Remote Office Hours Queue Meeting with {attendee_name}'
+
         # invoke the create_meeting method of the ZoomClient instance
         try:
             meeting = client.meetings.create_meeting(
-                topic='Remote Office Hours Queue Meeting',
+                topic=topic,
                 start_time=datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ'),
                 duration_min=60,
                 timezone='America/Detroit',
@@ -197,7 +201,9 @@ class Backend(BackendBase):
             backend_metadata = {}
         if backend_metadata.get('meeting_id'):
             return backend_metadata
-        meeting = cls._create_meeting(assignee)
+
+        attendee_name = backend_metadata.get('attendee_name')
+        meeting = cls._create_meeting(assignee, attendee_name)
         backend_metadata.update({
             'user_id': meeting['host_id'],
             'meeting_id': meeting['id'],

--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -201,8 +201,16 @@ class Meeting(SafeDeleteModel):
         if not backend:
             raise DisabledBackendException(self.backend_type)
         try:
+            attendee = self.attendees.first()
+            if attendee:
+                attendee_name = attendee.get_full_name()
+                if not attendee_name.strip():
+                    attendee_name = attendee.email
+                metadata = {'attendee_name': attendee_name}
+            else:
+                metadata = {}
             self.backend_metadata = backend.save_user_meeting(
-                self.backend_metadata,
+                metadata,
                 self.assignee,
             )
         except RequestException as ex:


### PR DESCRIPTION
Summary: Resolves #577 

Result is the screenshot below:
![Screenshot 2025-05-31 001311](https://github.com/user-attachments/assets/f451ee71-924d-4098-a021-b00bbe7cf46d)

If the user has a full name, add that to the title, otherwise just use their uniqname + email combo, like uniqname@umich.edu