### PR TITLE
refactor: changed queue.tsx to add more descriptive titles

### DIFF
--- a/src/assets/src/components/queue.tsx
+++ b/src/assets/src/components/queue.tsx
@@ -549,6 +549,17 @@ export function QueuePage(props: PageProps) {
     const loginDialogVisible = errorSources.some(checkForbiddenError);
     const loadingDisplay = <LoadingDisplay loading={isChanging}/>
     const errorDisplay = <ErrorDisplay formErrors={errorSources}/>
+
+    let queueTitle = queue?.name ?? queue_id.toString();
+    if (queue) {
+        if (!queue.my_meeting) {
+            queueTitle = `Join Queue: ${queue.name}`;
+        } else if (queue.my_meeting && queue.my_meeting.status === MeetingStatus.STARTED) {
+            queueTitle = `${queue.name} - In Meeting`;
+        } else {
+            queueTitle = `Queue: ${queue.name}`;
+        }
+    }
     const queueDisplay = queue && selectedBackend
         && (
             <QueueAttending
@@ -574,7 +585,7 @@ export function QueuePage(props: PageProps) {
             onChangeBackend={setSelectedBackend}/>
     return (
         <div>
-            <HelmetTitle title={queue?.name ?? queue_id.toString()} />
+            <HelmetTitle title={queueTitle} />
             <Dialog {...dialogState} />
             <LoginDialog visible={loginDialogVisible} loginUrl={props.loginUrl}/>
             {meetingTypeDialog}


### PR DESCRIPTION
Summary: fixes the following comment made in #436 

> Overall, the test looks good. I'm seeking input from the team on the following:
>  Under Manage, both Queue and Preferences are displaying correctly. However, once a user clicks Join Queue, the tab title changes to show only the [Title of the Queue] - Remote Office Hours Queue.
> When viewing as a visitor and clicking Join Queue, should the tab title be more descriptive? For example, something like:
> Queue: [Title of the Queue]
> Join Queue: [Title of the Queue]
> Currently, it just shows [Title of the Queue], which might not be as clear. Thoughts? (edited)  

 _Originally posted by @HemanginiShah in [#436](https://github.com/tl-its-umich-edu/remote-office-hours-queue/issues/436#issuecomment-2932598084)_

Results are the following:
![Screenshot 2025-06-02 191618](https://github.com/user-attachments/assets/9e6447e3-49f4-4d38-bf79-5c9eee3fddce)
![Screenshot 2025-06-02 191624](https://github.com/user-attachments/assets/3c3ad73a-2580-4399-84ea-e77e3d737533)
![Screenshot 2025-06-02 192014](https://github.com/user-attachments/assets/f87d9ca1-a865-4af2-b924-e6a33e1c8f65)
