### PR TITLE
ignore django-filter for auto update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       - dependency-name: "django"
         versions:
           - "> 4.2"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
+      # Update this manually when updating Django/Python to supported version
+      - dependency-name: "django-filter"
+        versions: ["*"]
     groups:
       all-python-dependencies:
         patterns: ["*"]


### PR DESCRIPTION
Added a comment to indicate manual update needed for Django/Python version.

Same approach as in https://github.com/tl-its-umich-edu/instructor-tools/pull/498 and https://github.com/tl-its-umich-edu/my-learning-analytics/pull/1689
