### PR TITLE
HW6b: Fix default allowed_backends to use static list instead of settings

### DIFF
--- a/src/officehours_api/models.py
+++ b/src/officehours_api/models.py
@@ -31,8 +31,15 @@ def get_default_backend():
 
 
 def get_default_allowed_backends():
-    return settings.DEFAULT_ALLOWED_BACKENDS
+    """
+    Return a static default list of allowed backends for new queues.
 
+    This is intentionally NOT based on deployment settings or environment
+    variables so that the database default does not change when configuration
+    changes. Queue allowed_backends should be adjusted per queue via Django
+    Admin instead.
+    """
+    return ['inperson']
 
 def get_backend_types() -> List[Tuple[IMPLEMENTED_BACKEND_NAME, str]]:
     """


### PR DESCRIPTION
This PR resolves a bug where new Queues inherited deployment-specific DEFAULT_ALLOWED_BACKENDS.
This caused inconsistencies in test environments and migrations.

Change:
- Replace `settings.DEFAULT_ALLOWED_BACKENDS` with a static default `['inperson']`.

Includes: screenshots, exploration notes, and local test runs as required for HW6b.
