### PR TITLE
Update dependabot.yml to modify dependency ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,8 @@ updates:
     allow:
       - dependency-type: "direct"
     ignore:
-      - dependency-name: "django"
-        versions:
-          - "> 4.2"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       # Update this manually when updating Django/Python to supported version
       - dependency-name: "django-filter"
         versions: ["*"]


### PR DESCRIPTION
Removed Django version ignore rule and added a wildcard ignore for major version updates to align with other apps. This would allow Dependabot to update Django and hold back others appropriately.