### PR TITLE
issue_723 upgrade mozilla-django-oidc version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@ psycopg2~=2.9.11
 Django==4.2.27
 djangorestframework==3.16.1
 drf-spectacular==0.29.0
-mozilla-django-oidc==4.0.1
+mozilla-django-oidc==5.0.2
 whitenoise==6.11.0
 dj-database-url==3.1.0
 requests==2.32.5


### PR DESCRIPTION
upgraded to the latest v5.0.2 of mozilla-django-oidc 