### PR TITLE
Add date range filter to queue history export (#693)

### DIFF
--- a/src/assets/src/components/SingleQueueHistoryDownload.tsx
+++ b/src/assets/src/components/SingleQueueHistoryDownload.tsx
@@ -17,7 +17,7 @@ const SingleQueueHistoryDownload: React.FC<SingleQueueHistoryDownloadProps> = ({
 
     return (
         <div className="queue-history-filter">
-            <Form.Group>
+            <Form.Group controlId={`queueHistoryFilter-${queueId}`}>
                 <Form.Label visuallyHidden>
                     {`Date range filter for Queue ID ${queueId}`}
                 </Form.Label>

--- a/src/assets/src/components/SingleQueueHistoryDownload.tsx
+++ b/src/assets/src/components/SingleQueueHistoryDownload.tsx
@@ -1,0 +1,43 @@
+import { faFileDownload } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useState } from "react";
+import { Button, Form } from "react-bootstrap";
+
+interface SingleQueueHistoryDownloadProps {
+    queueId: number;
+    onDownload: (queueId: number, days?: number) => Promise<void>;
+}
+
+const SingleQueueHistoryDownload: React.FC<SingleQueueHistoryDownloadProps> = ({ queueId, onDownload }) => {
+    const [selectedDays, setSelectedDays] = useState<number | undefined>(undefined);
+
+    const handleDownload = async () => {
+        await onDownload(queueId, selectedDays);
+    };
+
+    return (
+        <div className="queue-history-filter">
+            <Form.Group>
+                <Form.Label visuallyHidden>
+                    {`Date range filter for Queue ID ${queueId}`}
+                </Form.Label>
+                <Form.Select
+                    className="queue-history-filter-select"
+                    value={selectedDays ?? ''}
+                    onChange={(e) => setSelectedDays(e.target.value ? Number(e.target.value) : undefined)}
+                >
+                    <option value="">All history</option>
+                    <option value="90">Last 90 days</option>
+                    <option value="180">Last 180 days</option>
+                    <option value="365">Last 365 days</option>
+                </Form.Select>
+            </Form.Group>
+            <Button className="queue-history-filter-btn" onClick={handleDownload}>
+                <span style={{paddingRight:"8px"}}><FontAwesomeIcon icon={faFileDownload} /></span>
+                Download
+            </Button>
+        </div>
+    );
+};
+
+export default SingleQueueHistoryDownload;

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -11,6 +11,7 @@ import { useInitFocusRef } from "../hooks/useInitFocusRef";
 import { QueueAttendee, QueueBase, User } from "../models";
 import { sortQueues } from "../sort";
 import { ValidationResult } from "../validation";
+import SingleQueueHistoryDownload from "./SingleQueueHistoryDownload";
 
 type BootstrapButtonTypes = "info" | "warning" | "success" | "primary" | "alternate" | "danger";
 
@@ -527,12 +528,6 @@ interface QueueTableProps {
 
 export function QueueTable (props: QueueTableProps) {
     const linkBase = props.manageLink ? '/manage/' : '/queue/'
-    // Track which dropdown option is selected: undefined = all history, 90 = 90 days, etc
-    const [selectedDays, setSelectedDays] = useState<number | undefined>(undefined);
-    const handleQueueHistoryExportSubmit = async (queueId: number) => {
-        if (props.handleCSVDownload === undefined) return;
-        await props.handleCSVDownload(queueId, selectedDays);
-    }
 
     const sortedQueues = sortQueues(props.queues.slice());
     const queueItems = sortedQueues.map(q => (
@@ -554,27 +549,7 @@ export function QueueTable (props: QueueTableProps) {
             </td>
             {props.includeCSVDownload && props.handleCSVDownload && (
                 <td className="align-middle" aria-label={`History for Queue ID ${q.id}`}>
-                    <div className="queue-history-filter">
-                        <Form.Group>
-                            <Form.Label visuallyHidden>
-                                {`Date range filter for Queue ID ${q.id}`}
-                            </Form.Label>
-                            <Form.Select
-                                className="queue-history-filter-select"
-                                value={selectedDays ?? ''}
-                                onChange={(e) => setSelectedDays(e.target.value ? Number(e.target.value) : undefined)}
-                            >
-                                <option value="">All history</option>
-                                <option value="90">Last 90 days</option>
-                                <option value="180">Last 180 days</option>
-                                <option value="365">Last 365 days</option>
-                            </Form.Select>
-                        </Form.Group>
-                        <Button className="queue-history-filter-btn" onClick={() => handleQueueHistoryExportSubmit(q.id)}>
-                            <span style={{paddingRight:"8px"}}><FontAwesomeIcon icon={faFileDownload} /></span>
-                            Download
-                        </Button>
-                    </div>
+                    <SingleQueueHistoryDownload queueId={q.id} onDownload={props.handleCSVDownload} />
                 </td>
             )}
         </tr>

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -16,7 +16,7 @@ type BootstrapButtonTypes = "info" | "warning" | "success" | "primary" | "altern
 
 export const DisabledMessage = <em></em>
 
-
+ 
 interface UserDisplayProps {
     user: User;
 }
@@ -522,7 +522,7 @@ interface QueueTableProps {
     queues: readonly QueueBase[];
     manageLink?: boolean | undefined;
     includeCSVDownload?: boolean | undefined;
-    handleCSVDownload?: (queueId: number) => Promise<void>;
+    handleCSVDownload?: (queueId: number, days?: number) => Promise<void>;
 }
 
 export function QueueTable (props: QueueTableProps) {

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -554,23 +554,23 @@ export function QueueTable (props: QueueTableProps) {
             </td>
             {props.includeCSVDownload && props.handleCSVDownload && (
                 <td className="align-middle" aria-label={`History for Queue ID ${q.id}`}>
-                    <div className="d-flex align-items-center">
+                    <div style={{display: "flex", alignItems: "center", flexWrap: "nowrap"}}>
                         <Form.Select
                             aria-label={`Date range filter for Queue ID ${q.id}`}
                             value={selectedDays ?? ''}
                             onChange={(e) => setSelectedDays(e.target.value ? Number(e.target.value) : undefined)}
-                            style={{width: "auto", marginRight: "8px"}}
+                            style={{width: "auto", flex: "0 0 auto", marginRight: "8px"}}
                         >
                             <option value="">All history</option>
                             <option value="90">Last 90 days</option>
                             <option value="180">Last 180 days</option>
                             <option value="365">Last 365 days</option>
                         </Form.Select>
+                        <Button style={{whiteSpace: "nowrap"}} onClick={() => handleQueueHistoryExportSubmit(q.id)}>
+                            <span style={{paddingRight:"8px"}}><FontAwesomeIcon icon={faFileDownload} /></span>
+                            Download
+                        </Button>
                     </div>
-                    <Button onClick={() => handleQueueHistoryExportSubmit(q.id)}>
-                        <span style={{paddingRight:"8px"}}><FontAwesomeIcon icon={faFileDownload} /></span>
-                        Download
-                    </Button>
                 </td>
             )}
         </tr>

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -554,6 +554,19 @@ export function QueueTable (props: QueueTableProps) {
             </td>
             {props.includeCSVDownload && props.handleCSVDownload && (
                 <td className="align-middle" aria-label={`History for Queue ID ${q.id}`}>
+                    <div className="d-flex align-items-center">
+                        <Form.Select
+                            aria-label={`Date range filter for Queue ID ${q.id}`}
+                            value={selectedDays ?? ''}
+                            onChange={(e) => setSelectedDays(e.target.value ? Number(e.target.value) : undefined)}
+                            style={{width: "auto", marginRight: "8px"}}
+                        >
+                            <option value="">All history</option>
+                            <option value="90">Last 90 days</option>
+                            <option value="180">Last 180 days</option>
+                            <option value="365">Last 365 days</option>
+                        </Form.Select>
+                    </div>
                     <Button onClick={() => handleQueueHistoryExportSubmit(q.id)}>
                         <span style={{paddingRight:"8px"}}><FontAwesomeIcon icon={faFileDownload} /></span>
                         Download

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -17,7 +17,6 @@ type BootstrapButtonTypes = "info" | "warning" | "success" | "primary" | "altern
 
 export const DisabledMessage = <em></em>
 
- 
 interface UserDisplayProps {
     user: User;
 }

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -527,9 +527,11 @@ interface QueueTableProps {
 
 export function QueueTable (props: QueueTableProps) {
     const linkBase = props.manageLink ? '/manage/' : '/queue/'
+    // Track which dropdown option is selected: undefined = all history, 90 = 90 days, etc
+    const [selectedDays, setSelectedDays] = useState<number | undefined>(undefined);
     const handleQueueHistoryExportSubmit = async (queueId: number) => {
         if (props.handleCSVDownload === undefined) return;
-        await props.handleCSVDownload(queueId);
+        await props.handleCSVDownload(queueId, selectedDays);
     }
 
     const sortedQueues = sortQueues(props.queues.slice());

--- a/src/assets/src/components/common.tsx
+++ b/src/assets/src/components/common.tsx
@@ -554,19 +554,23 @@ export function QueueTable (props: QueueTableProps) {
             </td>
             {props.includeCSVDownload && props.handleCSVDownload && (
                 <td className="align-middle" aria-label={`History for Queue ID ${q.id}`}>
-                    <div style={{display: "flex", alignItems: "center", flexWrap: "nowrap"}}>
-                        <Form.Select
-                            aria-label={`Date range filter for Queue ID ${q.id}`}
-                            value={selectedDays ?? ''}
-                            onChange={(e) => setSelectedDays(e.target.value ? Number(e.target.value) : undefined)}
-                            style={{width: "auto", flex: "0 0 auto", marginRight: "8px"}}
-                        >
-                            <option value="">All history</option>
-                            <option value="90">Last 90 days</option>
-                            <option value="180">Last 180 days</option>
-                            <option value="365">Last 365 days</option>
-                        </Form.Select>
-                        <Button style={{whiteSpace: "nowrap"}} onClick={() => handleQueueHistoryExportSubmit(q.id)}>
+                    <div className="queue-history-filter">
+                        <Form.Group>
+                            <Form.Label visuallyHidden>
+                                {`Date range filter for Queue ID ${q.id}`}
+                            </Form.Label>
+                            <Form.Select
+                                className="queue-history-filter-select"
+                                value={selectedDays ?? ''}
+                                onChange={(e) => setSelectedDays(e.target.value ? Number(e.target.value) : undefined)}
+                            >
+                                <option value="">All history</option>
+                                <option value="90">Last 90 days</option>
+                                <option value="180">Last 180 days</option>
+                                <option value="365">Last 365 days</option>
+                            </Form.Select>
+                        </Form.Group>
+                        <Button className="queue-history-filter-btn" onClick={() => handleQueueHistoryExportSubmit(q.id)}>
                             <span style={{paddingRight:"8px"}}><FontAwesomeIcon icon={faFileDownload} /></span>
                             Download
                         </Button>

--- a/src/assets/src/components/manage.tsx
+++ b/src/assets/src/components/manage.tsx
@@ -61,8 +61,8 @@ export function ManagePage(props: PageProps) {
     }
     const [queues, setQueues] = useState(undefined as ReadonlyArray<QueueBase> | undefined);
     const userWebSocketError = useUserWebSocket(props.user!.id, (u) => setQueues(u.hosted_queues));
-    const [ doExportAllQueues, exportAllLoading, exportAllError ] = usePromise(() => api.exportAllQueueHistoryLogs() as Promise<void>);
-    const [ doExportQueue, exportQueueLoading, exportQueueError ] = usePromise((queueId: number) => api.exportQueueHistoryLogs(queueId) as Promise<void>);
+    const [ doExportAllQueues, exportAllLoading, exportAllError ] = usePromise((days?: number) => api.exportAllQueueHistoryLogs(days) as Promise<void>);
+    const [ doExportQueue, exportQueueLoading, exportQueueError ] = usePromise((queueId: number, days?: number) => api.exportQueueHistoryLogs(queueId, days) as Promise<void>);
 
     
     const errorSources = [

--- a/src/assets/src/components/manage.tsx
+++ b/src/assets/src/components/manage.tsx
@@ -35,18 +35,22 @@ function ManageQueueTable(props: ManageQueueTableProps) {
                 </Link>
                 {props.onAllQueueHistoryDownload ? (
                     <>
-                        <Form.Select
-                            aria-label='Date range filter for all queue history'
-                            value={selectedAllDays ?? ''}
-                            onChange={(e) => setSelectedAllDays(e.target.value ? Number(e.target.value) : undefined)}
-                            style={{width: "auto", display: "inline-block", marginLeft: "4px"}}
-                            disabled={props.disabled}
-                        >
-                            <option value="">All history</option>
-                            <option value="90">Last 90 days</option>
-                            <option value="180">Last 180 days</option>
-                            <option value="365">Last 365 days</option>
-                        </Form.Select>
+                        <Form.Group className="d-inline">
+                            <Form.Label visuallyHidden>
+                                Date range filter for all queue history
+                            </Form.Label>
+                            <Form.Select
+                                className="queue-history-filter-all"
+                                value={selectedAllDays ?? ''}
+                                onChange={(e) => setSelectedAllDays(e.target.value ? Number(e.target.value) : undefined)}
+                                disabled={props.disabled}
+                            >
+                                <option value="">All history</option>
+                                <option value="90">Last 90 days</option>
+                                <option value="180">Last 180 days</option>
+                                <option value="365">Last 365 days</option>
+                            </Form.Select>
+                        </Form.Group>
                         <DownloadQueueHistoryModal disabled={props.disabled} onDownload={() => props.onAllQueueHistoryDownload!(selectedAllDays)} />
                     </>
                 ) : null}

--- a/src/assets/src/components/manage.tsx
+++ b/src/assets/src/components/manage.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { Button } from "react-bootstrap";
-
+import { Button, Form } from "react-bootstrap";
+ 
 import { Breadcrumbs, checkForbiddenError, ErrorDisplay, FormError, LoginDialog, QueueTable } from "./common";
 import { PageProps } from "./page";
 import { QueueBase } from "../models";
@@ -16,11 +16,13 @@ import { HelmetTitle } from "./pageTitle";
 interface ManageQueueTableProps {
     queues: ReadonlyArray<QueueBase>;
     disabled: boolean;
-    onSingleQueueHistoryDownload?: (queueId: number) => Promise<void>;
-    onAllQueueHistoryDownload?: () => Promise<void>;
+    onSingleQueueHistoryDownload?: (queueId: number, days?: number) => Promise<void>;
+    onAllQueueHistoryDownload?: (days?: number) => Promise<void>;
 }
 
 function ManageQueueTable(props: ManageQueueTableProps) {
+    // Track dropdown selection
+    const [selectedAllDays, setSelectedAllDays] = useState<number | undefined>(undefined);
     const queueResults = props.queues.length
         ? <QueueTable queues={props.queues} manageLink={true} includeCSVDownload={true} handleCSVDownload={props.onSingleQueueHistoryDownload} />
         : <p>No queues to display. Create a queue by clicking the "Add Queue" button below.</p>;
@@ -32,7 +34,21 @@ function ManageQueueTable(props: ManageQueueTableProps) {
                     <Button disabled={props.disabled} variant='success' aria-label='Add Queue'>+ Add Queue</Button>
                 </Link>
                 {props.onAllQueueHistoryDownload ? (
-                    <DownloadQueueHistoryModal disabled={props.disabled} onDownload={props.onAllQueueHistoryDownload} />
+                    <>
+                        <Form.Select
+                            aria-label='Date range filter for all queue history'
+                            value={selectedAllDays ?? ''}
+                            onChange={(e) => setSelectedAllDays(e.target.value ? Number(e.target.value) : undefined)}
+                            style={{width: "auto", display: "inline-block", marginLeft: "4px"}}
+                            disabled={props.disabled}
+                        >
+                            <option value="">All history</option>
+                            <option value="90">Last 90 days</option>
+                            <option value="180">Last 180 days</option>
+                            <option value="365">Last 365 days</option>
+                        </Form.Select>
+                        <DownloadQueueHistoryModal disabled={props.disabled} onDownload={() => props.onAllQueueHistoryDownload!(selectedAllDays)} />
+                    </>
                 ) : null}
             </div>
         </div>

--- a/src/assets/src/components/manage.tsx
+++ b/src/assets/src/components/manage.tsx
@@ -35,7 +35,7 @@ function ManageQueueTable(props: ManageQueueTableProps) {
                 </Link>
                 {props.onAllQueueHistoryDownload ? (
                     <>
-                        <Form.Group className="d-inline">
+                        <Form.Group className="d-inline" controlId="allQueueHistoryFilter">
                             <Form.Label visuallyHidden>
                                 Date range filter for all queue history
                             </Form.Label>

--- a/src/assets/src/services/api.ts
+++ b/src/assets/src/services/api.ts
@@ -7,7 +7,7 @@ import {
   Meeting,
   QueueAnnouncement,
 } from "../models";
-
+ 
 const getCsrfToken = () => {
   return (
     document.querySelector("[name='csrfmiddlewaretoken']") as HTMLInputElement
@@ -345,8 +345,15 @@ export const startMeeting = async (meeting_id: number) => {
   return (await resp.json()) as Meeting;
 };
 
-export const exportQueueHistoryLogs = async (queue_id: number) => {
-  const resp = await fetch(`/api/export_meeting_start_logs/${queue_id}/`, {
+export const exportQueueHistoryLogs = async (queue_id: number, days?: number) => {
+  let url = '/api/export_meeting_start_logs/${queue_id}';
+  if (days) {
+    const start_date = new Date();
+    start_date.setDate(start_date.getDate() - days);
+    // Convert date and grab only YYYY-MM-DD that backend is expecting
+    url += '?start_date=${start_date.toISOString().split('T')[0]}';
+  }
+  const resp = await fetch(url, {
     method: "GET",
   });
   await handleErrors(resp);

--- a/src/assets/src/services/api.ts
+++ b/src/assets/src/services/api.ts
@@ -364,8 +364,15 @@ export const exportQueueHistoryLogs = async (queue_id: number, days?: number) =>
   await downloadCsv(resp);
 };
 
-export const exportAllQueueHistoryLogs = async () => {
-  const resp = await fetch(`/api/export_meeting_start_logs/`, {
+export const exportAllQueueHistoryLogs = async (days?: number) => {
+  let url = '/api/export_meeting_start_logs/';
+  if (days) {
+    const start_date = new Date();
+    start_date.setDate(start_date.getDate() - days);
+    // Convert date and grab only YYYY-MM-DD that backend is expecting
+    url += '?start_date=${start_date.toISOString().split('T')[0]}';
+  }
+  const resp = await fetch(url, {
     method: "GET",
   });
   await handleErrors(resp);

--- a/src/assets/src/services/api.ts
+++ b/src/assets/src/services/api.ts
@@ -346,12 +346,12 @@ export const startMeeting = async (meeting_id: number) => {
 };
 
 export const exportQueueHistoryLogs = async (queue_id: number, days?: number) => {
-  let url = '/api/export_meeting_start_logs/${queue_id}';
+  let url = `/api/export_meeting_start_logs/${queue_id}`;
   if (days) {
     const start_date = new Date();
     start_date.setDate(start_date.getDate() - days);
     // Convert date and grab only YYYY-MM-DD that backend is expecting
-    url += '?start_date=${start_date.toISOString().split('T')[0]}';
+    url += `?start_date=${start_date.toISOString().split('T')[0]}`;
   }
   const resp = await fetch(url, {
     method: "GET",
@@ -365,12 +365,12 @@ export const exportQueueHistoryLogs = async (queue_id: number, days?: number) =>
 };
 
 export const exportAllQueueHistoryLogs = async (days?: number) => {
-  let url = '/api/export_meeting_start_logs/';
+  let url = `/api/export_meeting_start_logs/`;
   if (days) {
     const start_date = new Date();
     start_date.setDate(start_date.getDate() - days);
     // Convert date and grab only YYYY-MM-DD that backend is expecting
-    url += '?start_date=${start_date.toISOString().split('T')[0]}';
+    url += `?start_date=${start_date.toISOString().split('T')[0]}`;
   }
   const resp = await fetch(url, {
     method: "GET",

--- a/src/officehours_api/test_views.py
+++ b/src/officehours_api/test_views.py
@@ -182,6 +182,35 @@ class MeetingTestCase(TestCase):
         response_csv = self.read_csv_from_response(response.content)
         # Just check right now that there's a header row and a data row, perhaps do more validation later
         self.assertEqual(len(response_csv), 3)
+        
+    def test_export_meeting_start_logs_with_start_date_today(self):
+        self.test_export_setup()
+        self.client.login(username='hostone', password='rohqtest')
+        # Use today's date as start_date; all meetings were just created so they should all appear
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        response = self.client.get(f'/api/export_meeting_start_logs/?start_date={today}')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_csv = self.read_csv_from_response(response.content)
+        # Should have the same results as without a filter (header row + 2 data rows)
+        self.assertEqual(len(response_csv), 3)
+
+    def test_export_meeting_start_logs_with_start_date_future(self):
+        self.test_export_setup()
+        self.client.login(username='hostone', password='rohqtest')
+        # Use a future date as start_date; no meetings should match
+        future_date = (datetime.now(timezone.utc) + timedelta(days=1)).strftime('%Y-%m-%d')
+        response = self.client.get(f'/api/export_meeting_start_logs/?start_date={future_date}')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_csv = self.read_csv_from_response(response.content)
+        # Should only have the header row, no data rows
+        self.assertEqual(len(response_csv), 1)
+
+    def test_export_meeting_start_logs_with_invalid_start_date(self):
+        self.test_export_setup()
+        self.client.login(username='hostone', password='rohqtest')
+        # Pass an invalid date string
+        response = self.client.get(f'/api/export_meeting_start_logs/?start_date=not-a-date')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 @skipIf(notifications.twilio is None, 'Skipping because "twilio" is not configured')
 @override_settings(TWILIO_ACCOUNT_SID='fake', TWILIO_AUTH_TOKEN='fake', TWILIO_MESSAGING_SERVICE_SID='fake')

--- a/src/officehours_api/test_views.py
+++ b/src/officehours_api/test_views.py
@@ -183,12 +183,11 @@ class MeetingTestCase(TestCase):
         # Just check right now that there's a header row and a data row, perhaps do more validation later
         self.assertEqual(len(response_csv), 3)
         
-    def test_export_meeting_start_logs_with_start_date_today(self):
+    def test_export_meeting_start_logs_with_start_date_includes_all(self):
         self.test_export_setup()
         self.client.login(username='hostone', password='rohqtest')
-        # Use today's date as start_date; all meetings were just created so they should all appear
-        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-        response = self.client.get(f'/api/export_meeting_start_logs/?start_date={today}')
+        # Use a past date as start_date; all meetings were just created so they should all appear
+        response = self.client.get(f'/api/export_meeting_start_logs/?start_date=2000-01-01')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_csv = self.read_csv_from_response(response.content)
         # Should have the same results as without a filter (header row + 2 data rows)

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -394,10 +394,19 @@ class ExportMeetingStartLogs(APIView):
     def extract_log(queue_ids: Iterable[int], response: HttpResponse, start_date: Optional[datetime] = None) -> None:
         writer = csv.writer(response)
         with connection.cursor() as cursor:
-            cursor.execute('''
+            query = '''
                 SELECT * FROM meeting_start_logs
                 WHERE queue_id = ANY(%s)
-                ''', [list(queue_ids)])
+            '''
+            params = [list(queue_ids)]
+
+            # Only add the date filter if user asked for one 
+            if start_date:
+                query += ' AND meeting_created_at >= %s'
+                # Add datetime object to param list, Django should handle converting it to postgres compatible timestamp
+                params.append(start_date)
+
+            cursor.execute(query, params)
 
             rows = cursor.fetchall()
 

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -368,7 +368,7 @@ class ExportMeetingStartLogs(APIView):
         # Otherwise, get all the logs for the queues the user is a host of
         else:
             filename = f"meeting_start_logs_{username}.csv"
-        # Parse optional start_date queury parameter in order to filter by date
+        # Parse optional start_date query parameter in order to filter by date
         start_date_str = request.query_params.get('start_date')
         start_date = None
         # If no filter chosen, return everything
@@ -378,7 +378,7 @@ class ExportMeetingStartLogs(APIView):
                 start_date = datetime.strptime(start_date_str, '%Y-%m-%d').replace(tzinfo=timezone.utc)
             except ValueError:
                 return Response(
-                    {'detail': 'Invalid start_date formate. Use YYYY-MM-DD.'},
+                    {'detail': 'Invalid start_date format. Use YYYY-MM-DD.'},
                     status=status.HTTP_400_BAD_REQUEST
                 )
         logger.info(f"User {username} requested to export meeting start logs for queues {queues_user_is_in}.")

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -375,9 +375,9 @@ class ExportMeetingStartLogs(APIView):
         if start_date_str:
             try:
                 # attach UTC to avoid issues with postgres and comparing timezone-aware column against a naive datetime
-                start_date = datetime.strptime(start_date_str, '%Y-%M-%d').replace(tzinfo=timezone.utc)
+                start_date = datetime.strptime(start_date_str, '%Y-%m-%d').replace(tzinfo=timezone.utc)
             except ValueError:
-                return response(
+                return Response(
                     {'detail': 'Invalid start_date formate. Use YYYY-MM-DD.'},
                     status=status.HTTP_400_BAD_REQUEST
                 )

--- a/src/officehours_api/views.py
+++ b/src/officehours_api/views.py
@@ -2,7 +2,7 @@ import csv
 import logging
 from datetime import datetime, timezone, timedelta
 from random import randint
-from typing import Iterable
+from typing import Iterable, Optional
 
 from asgiref.sync import async_to_sync
 from django.conf import settings
@@ -368,18 +368,30 @@ class ExportMeetingStartLogs(APIView):
         # Otherwise, get all the logs for the queues the user is a host of
         else:
             filename = f"meeting_start_logs_{username}.csv"
-
+        # Parse optional start_date queury parameter in order to filter by date
+        start_date_str = request.query_params.get('start_date')
+        start_date = None
+        # If no filter chosen, return everything
+        if start_date_str:
+            try:
+                # attach UTC to avoid issues with postgres and comparing timezone-aware column against a naive datetime
+                start_date = datetime.strptime(start_date_str, '%Y-%M-%d').replace(tzinfo=timezone.utc)
+            except ValueError:
+                return response(
+                    {'detail': 'Invalid start_date formate. Use YYYY-MM-DD.'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
         logger.info(f"User {username} requested to export meeting start logs for queues {queues_user_is_in}.")
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = f'attachment; filename="{filename}"'
 
         logger.info(f"User {username} successfully exported meeting start logs for queues {repr(queues_user_is_in)}.")
-        self.extract_log(queues_user_is_in, response)
+        self.extract_log(queues_user_is_in, response, start_date)
 
         return response
 
     @staticmethod
-    def extract_log(queue_ids: Iterable[int], response: HttpResponse) -> None:
+    def extract_log(queue_ids: Iterable[int], response: HttpResponse, start_date: Optional[datetime] = None) -> None:
         writer = csv.writer(response)
         with connection.cursor() as cursor:
             cursor.execute('''

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -793,3 +793,9 @@ body {
 .queue-history-filter-btn {
 	white-space: nowrap;
 }
+
+.queue-history-filter-all {
+	width: auto;
+	display: inline-block;
+	margin-left: 4px;
+}

--- a/src/officehours_ui/static/css/main.css
+++ b/src/officehours_ui/static/css/main.css
@@ -777,3 +777,19 @@ body {
 	text-align: center;
 	color: #9B9B9B
 }
+
+.queue-history-filter {
+	display: flex;
+	align-items: center;
+	flex-wrap: nowrap;
+}
+
+.queue-history-filter-select {
+	width: auto;
+	flex: 0 0 auto;
+	margin-right: 8px;
+}
+
+.queue-history-filter-btn {
+	white-space: nowrap;
+}


### PR DESCRIPTION
Resolves #693

## Summary

Adds a date range dropdown menu to queue history exports for individual and all queues. Users can now select "All history" (default), "Last 90 days", "Last 180 days", or "Last 365 days" before downloading a CSV. 

## Changes

### Backend (`src/officehours_api/views.py`)
- `ExportMeetingStartLogs` view now accepts an optional `start_date` query parameter (format: `YYYY-MM-DD`)
- When provided, filters the `meeting_start_logs` query with `AND meeting_created_at >= start_date`
- Returns `400 Bad Request` with a descriptive message for invalid date formats
- backward compatible: omitting the parameter returns all data, same behavior as before

### Frontend
- **`src/assets/src/components/common.tsx`**: Added a date range dropdown next to each per-queue Download button in the QueueTable
- **`src/assets/src/components/manage.tsx`**: Added a date range dropdown next to the "Download All Queue History" button on the Manage page. The existing confirmation modal is preserved.
- **`src/assets/src/services/api.ts`**: Updated `exportQueueHistoryLogs` and `exportAllQueueHistoryLogs` to accept an optional `days` parameter, which computes a `start_date` and appends it as a query string

### 3 New Tests (`src/officehours_api/test_views.py`)
- `test_export_meeting_start_logs_with_start_date_includes_all`: Verifies that a past start_date returns all data
- `test_export_meeting_start_logs_with_start_date_future`: Verifies that a future start_date excludes all data (only header row returned)
- `test_export_meeting_start_logs_with_invalid_start_date`: Verifies that an invalid date string returns 400
